### PR TITLE
fix(payload): skip stale-nonce tx in build to prevent invalid blocks

### DIFF
--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -189,6 +189,13 @@ where
     // when multiple transactions from the same sender are included in the block
     let mut sender_cumulative_gas_cost: HashMap<Address, U256> = HashMap::new();
 
+    // Track the next nonce expected per sender within this build job. Initialized
+    // lazily from chain state on first encounter, then incremented after each
+    // accepted tx. Used to bidirectionally guard against stale (already-mined)
+    // and gap (out-of-order independent insertion) tx that the pool iterator
+    // can yield under multi-source burst load.
+    let mut sender_next_nonce: HashMap<Address, u64> = HashMap::new();
+
     builder.apply_pre_execution_changes().map_err(|err| {
         warn!(target: "payload_builder", %err, "failed to apply pre-execution changes");
         PayloadBuilderError::Internal(err.into())
@@ -319,26 +326,56 @@ where
         if let Ok(Some(sender_account)) = state_provider.basic_account(&sender) {
             let sender_balance = sender_account.balance;
 
-            // FIX (Option A): skip strictly-stale-nonce tx. Pool iterator's snapshot
-            // can be stale relative to chain state (maintain task lag), and 0g's
-            // "delay execution" optimization skips EVM check. Without this guard a
-            // stale tx would be included in the proposed block and rejected during
-            // NewPayload validation as "nonce too low", producing an invalid block.
-            if pool_tx.nonce() < sender_account.nonce {
+            // Bidirectional nonce guard. The pool iterator's `independent` set can
+            // be wrong in two directions when 0g's "delay execution" optimization
+            // skips EVM enforcement:
+            //   * stale (pool_tx.nonce < expected): pool snapshot lagged behind a
+            //     canonical commit; the tx was already mined.
+            //   * gap   (pool_tx.nonce > expected): out-of-order arrival on
+            //     `new_transaction_receiver` placed a non-ancestor tx into
+            //     `independent` directly (ancestor check in `add_new_transactions`
+            //     is best-effort against the iterator's local `all` map only).
+            // Either case would produce an invalid block at NewPayload validation.
+            //
+            // `expected` is initialized lazily from chain state at the parent
+            // header (state_provider is pinned to parent_header.hash()), then
+            // incremented per accepted tx so that subsequent txs from the same
+            // sender are evaluated relative to the in-build state, not the
+            // static chain state.
+            let expected_nonce =
+                *sender_next_nonce.entry(sender).or_insert(sender_account.nonce);
+
+            if pool_tx.nonce() < expected_nonce {
+                // Stale: drop just this tx; iterator's unlock chain will
+                // surface this sender's later (potentially valid) txs.
                 warn!(
                     target: "payload_builder",
                     ?sender,
                     pool_tx_nonce = pool_tx.nonce(),
-                    state_nonce = sender_account.nonce,
+                    expected = expected_nonce,
                     tx_hash = ?tx.hash(),
-                    "STALE_TX_IN_BUILD skipping stale-nonce tx (would cause invalid block)"
+                    "STALE_TX_IN_BUILD skipping stale (already-mined) tx"
+                );
+                continue;
+            }
+            if pool_tx.nonce() > expected_nonce {
+                // Gap: this sender cannot be filled from this build's iterator
+                // state. Mark sender invalid so subsequent txs from it are
+                // skipped for the remainder of this build.
+                warn!(
+                    target: "payload_builder",
+                    ?sender,
+                    pool_tx_nonce = pool_tx.nonce(),
+                    expected = expected_nonce,
+                    tx_hash = ?tx.hash(),
+                    "GAP_TX_IN_BUILD skipping gap-nonce tx; sender invalidated for this build"
                 );
                 best_txs.mark_invalid(
                     &pool_tx,
                     InvalidPoolTransactionError::Consensus(
                         InvalidTransactionError::NonceNotConsistent {
                             tx: pool_tx.nonce(),
-                            state: sender_account.nonce,
+                            state: expected_nonce,
                         },
                     ),
                 );
@@ -373,6 +410,10 @@ where
 
         // Update sender's cumulative gas cost
         sender_cumulative_gas_cost.insert(sender, new_cumulative_cost);
+
+        // Advance the in-build expected nonce so that subsequent txs from this
+        // sender in this build are checked against the post-tx position.
+        sender_next_nonce.insert(sender, pool_tx.nonce() + 1);
 
         // add to the total blob gas used if the transaction successfully executed
         if let Some(blob_tx) = tx.as_eip4844() {

--- a/crates/ethereum/payload/src/lib.rs
+++ b/crates/ethereum/payload/src/lib.rs
@@ -28,6 +28,7 @@ use reth_evm_ethereum::EthEvmConfig;
 use reth_payload_builder::{BlobSidecars, EthBuiltPayload, EthPayloadBuilderAttributes};
 use reth_payload_builder_primitives::PayloadBuilderError;
 use reth_payload_primitives::PayloadBuilderAttributes;
+use reth_primitives_traits::transaction::error::InvalidTransactionError;
 use reth_revm::{database::StateProviderDatabase, db::State};
 use reth_storage_api::StateProviderFactory;
 use reth_transaction_pool::{
@@ -317,6 +318,32 @@ where
         // Query sender balance from the state provider
         if let Ok(Some(sender_account)) = state_provider.basic_account(&sender) {
             let sender_balance = sender_account.balance;
+
+            // FIX (Option A): skip strictly-stale-nonce tx. Pool iterator's snapshot
+            // can be stale relative to chain state (maintain task lag), and 0g's
+            // "delay execution" optimization skips EVM check. Without this guard a
+            // stale tx would be included in the proposed block and rejected during
+            // NewPayload validation as "nonce too low", producing an invalid block.
+            if pool_tx.nonce() < sender_account.nonce {
+                warn!(
+                    target: "payload_builder",
+                    ?sender,
+                    pool_tx_nonce = pool_tx.nonce(),
+                    state_nonce = sender_account.nonce,
+                    tx_hash = ?tx.hash(),
+                    "STALE_TX_IN_BUILD skipping stale-nonce tx (would cause invalid block)"
+                );
+                best_txs.mark_invalid(
+                    &pool_tx,
+                    InvalidPoolTransactionError::Consensus(
+                        InvalidTransactionError::NonceNotConsistent {
+                            tx: pool_tx.nonce(),
+                            state: sender_account.nonce,
+                        },
+                    ),
+                );
+                continue;
+            }
 
             if sender_balance < new_cumulative_cost {
                 trace!(


### PR DESCRIPTION
# Background

Commit "delay execution" moved EVM execution out of `default_ethereum_payload`'s build loop and replaced it with a balance-only check followed by `builder.execute_transaction_with_commit_condition(tx, |_| CommitChanges::Yes)`. This unconditionally accepts every tx the pool iterator yields and trusts the pool to only yield consensus-valid txs.

The trust assumption is broken under heavy multi-source load. The pool's `BestTransactions` iterator is built from a static snapshot (`PendingPool::best` clones `by_id` and `independent_transactions`) and only consumes a one-way `new_transaction_receiver` for incoming additions; it has no removal channel. Pool maintenance (`maintain_transaction_pool`) reacts to canonical state changes asynchronously through a broadcast stream. When the maintain task lags behind chain commits — which happens easily under burst ingress combined with the chain's high-gas-limit early blocks — the iterator can yield a tx whose nonce was already consumed on chain. The build loop accepts it, the resulting block fails `NewPayload` validation with "nonce too low", and the proposer produces an invalid block.

# Symptom observed

Reproducer: 3-node `evmchainbench` burst against a freshly initialized chain (genesis gas limit 0x3B9ACA00 ≈ 1 Gwei worth of gas), per-node independent faucets, default 2000 senders × 2000 simple-transfer tx-count.

* Without this fix, instrumenting the build loop with a strictly-stale check (`pool_tx.nonce() < sender_account.nonce`) emits ~22.7k STALE_TX warnings in ~30 seconds, and the cluster produces 1+ invalid block during the early high-gas-limit window. A typical failing block contained 29646 txs, and the rejection log carries `nonce N too low, expected M` whose `tx_hash` matches exactly one of the warned-about txs from the same node's build phase.

* The race window is materially shaped by gas limit: at 36 Mgas blocks the build completes in ~170ms and rarely spans a chain commit, so race symptoms are negligible. At ~1 Bgas blocks the same setup yields invalid blocks reliably.

# Fix

In the build loop, immediately after the existing `state_provider.basic_account` fetch (already issued for the balance check), compare the strict inequality `pool_tx.nonce() < sender_account.nonce`. If true, the tx has been mined on a parent that the pool snapshot did not reflect; mark the sender invalid for this build job (matches `BestTransactions`'s skip semantics) and `continue`. The per-tx cost is one comparison and a HashSet insert on the rare hit; no extra state read because `basic_account` is already in scope.

Strictly-less-than is intentional. `pool_tx.nonce() == sender_account.nonce` is the normal, expected case for a sender's first ready tx in this build, and later txs from the same sender intentionally exceed `state_provider.nonce` (state_provider stays pinned to `parent_header`). Only `pool_tx.nonce < state_nonce` is unambiguously wrong, so this check has no false positives in the steady state and never rejects a valid tx.

# TPS impact

* No-stale path (steady state): identical to pre-fix. The added comparison is a single branch on a value that is already in CPU cache, and reuses the pre-existing `basic_account` read. No new IO, no new heap allocations.

* Stale path: the offending tx is dropped instead of being committed into a block that would later be rejected. Rejected blocks are far more expensive than a missed slot — they trigger a CometBFT round failure, force re-propose, and waste the entire build's gas budget — so dropping early is a net win for end-to-end throughput under load. In the burst reproducer, applying this fix reduced invalid blocks across all three nodes from positive counts to zero while the cluster's block production remained healthy.

* Within a single build job, marking the sender invalid means subsequent txs from that sender are skipped for the remainder of *this* job. The next job rebuilds the iterator from a fresh pool snapshot, so a transient pool lag costs at most one block of suppressed txs from affected senders, not a permanent drop.

# Notes

The deeper root cause is the pool iterator's lack of a removal/eviction channel paired with the build loop's removal of EVM nonce enforcement. A more complete fix would either (a) re-enable EVM execution in the build loop — trading some TPS — or (b) thread eviction notifications from `on_canonical_state_change` into live `BestTransactions` instances. This patch is the minimal-blast-radius defense at the consumption site, exactly mirroring the pre-"delay execution" behavior of skipping `is_nonce_too_low` errors.