### PR TITLE
perpstate: persist off-trie perp state + on-trie commitment (crash-recovery validated)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,6 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.21.3"
-source = "git+https://github.com/0gfoundation/alloy-evm?rev=d9253fe11c5c9d229231df15bfd928619ee53c08#d9253fe11c5c9d229231df15bfd928619ee53c08"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6319,7 +6318,6 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "10.1.0"
-source = "git+https://github.com/0gfoundation/revm?rev=9bbdc91b26d41494b7870b2475e1ed4727eff8fc#9bbdc91b26d41494b7870b2475e1ed4727eff8fc"
 dependencies = [
  "auto_impl",
  "revm",
@@ -10072,6 +10070,7 @@ version = "1.8.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
+ "parking_lot",
  "reth-ethereum-forks",
  "reth-primitives-traits",
  "reth-storage-api",
@@ -11005,7 +11004,6 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "29.0.1"
-source = "git+https://github.com/0gfoundation/revm?rev=9bbdc91b26d41494b7870b2475e1ed4727eff8fc#9bbdc91b26d41494b7870b2475e1ed4727eff8fc"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -11023,7 +11021,6 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "6.2.2"
-source = "git+https://github.com/0gfoundation/revm?rev=9bbdc91b26d41494b7870b2475e1ed4727eff8fc#9bbdc91b26d41494b7870b2475e1ed4727eff8fc"
 dependencies = [
  "bitvec",
  "phf",
@@ -11034,7 +11031,6 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "9.1.0"
-source = "git+https://github.com/0gfoundation/revm?rev=9bbdc91b26d41494b7870b2475e1ed4727eff8fc#9bbdc91b26d41494b7870b2475e1ed4727eff8fc"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -11050,7 +11046,6 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "10.2.0"
-source = "git+https://github.com/0gfoundation/revm?rev=9bbdc91b26d41494b7870b2475e1ed4727eff8fc#9bbdc91b26d41494b7870b2475e1ed4727eff8fc"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -11065,7 +11060,6 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "7.0.5"
-source = "git+https://github.com/0gfoundation/revm?rev=9bbdc91b26d41494b7870b2475e1ed4727eff8fc#9bbdc91b26d41494b7870b2475e1ed4727eff8fc"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -11078,7 +11072,6 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "7.0.5"
-source = "git+https://github.com/0gfoundation/revm?rev=9bbdc91b26d41494b7870b2475e1ed4727eff8fc#9bbdc91b26d41494b7870b2475e1ed4727eff8fc"
 dependencies = [
  "auto_impl",
  "either",
@@ -11090,7 +11083,6 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "10.0.1"
-source = "git+https://github.com/0gfoundation/revm?rev=9bbdc91b26d41494b7870b2475e1ed4727eff8fc#9bbdc91b26d41494b7870b2475e1ed4727eff8fc"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -11108,7 +11100,6 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "10.0.1"
-source = "git+https://github.com/0gfoundation/revm?rev=9bbdc91b26d41494b7870b2475e1ed4727eff8fc#9bbdc91b26d41494b7870b2475e1ed4727eff8fc"
 dependencies = [
  "auto_impl",
  "either",
@@ -11145,7 +11136,6 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "25.0.3"
-source = "git+https://github.com/0gfoundation/revm?rev=9bbdc91b26d41494b7870b2475e1ed4727eff8fc#9bbdc91b26d41494b7870b2475e1ed4727eff8fc"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -11156,7 +11146,6 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "27.0.0"
-source = "git+https://github.com/0gfoundation/revm?rev=9bbdc91b26d41494b7870b2475e1ed4727eff8fc#9bbdc91b26d41494b7870b2475e1ed4727eff8fc"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -11188,7 +11177,6 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "20.2.1"
-source = "git+https://github.com/0gfoundation/revm?rev=9bbdc91b26d41494b7870b2475e1ed4727eff8fc#9bbdc91b26d41494b7870b2475e1ed4727eff8fc"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -11199,7 +11187,6 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "7.0.5"
-source = "git+https://github.com/0gfoundation/revm?rev=9bbdc91b26d41494b7870b2475e1ed4727eff8fc#9bbdc91b26d41494b7870b2475e1ed4727eff8fc"
 dependencies = [
  "bitflags 2.11.1",
  "revm-bytecode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10072,7 +10072,6 @@ version = "1.8.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
- "parking_lot",
  "reth-ethereum-forks",
  "reth-primitives-traits",
  "reth-storage-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3280,7 +3280,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4600,7 +4600,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5052,7 +5052,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6319,7 +6319,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "10.1.0"
-source = "git+https://github.com/0gfoundation/revm?rev=23e8e45813af0832e398544e60d51ffc65b09070#23e8e45813af0832e398544e60d51ffc65b09070"
+source = "git+https://github.com/0gfoundation/revm?rev=a7b0699dd52ac33e9e5f4b8e9165157a72d80d91#a7b0699dd52ac33e9e5f4b8e9165157a72d80d91"
 dependencies = [
  "auto_impl",
  "revm",
@@ -11005,7 +11005,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "29.0.1"
-source = "git+https://github.com/0gfoundation/revm?rev=23e8e45813af0832e398544e60d51ffc65b09070#23e8e45813af0832e398544e60d51ffc65b09070"
+source = "git+https://github.com/0gfoundation/revm?rev=a7b0699dd52ac33e9e5f4b8e9165157a72d80d91#a7b0699dd52ac33e9e5f4b8e9165157a72d80d91"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -11023,7 +11023,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "6.2.2"
-source = "git+https://github.com/0gfoundation/revm?rev=23e8e45813af0832e398544e60d51ffc65b09070#23e8e45813af0832e398544e60d51ffc65b09070"
+source = "git+https://github.com/0gfoundation/revm?rev=a7b0699dd52ac33e9e5f4b8e9165157a72d80d91#a7b0699dd52ac33e9e5f4b8e9165157a72d80d91"
 dependencies = [
  "bitvec",
  "phf",
@@ -11034,7 +11034,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "9.1.0"
-source = "git+https://github.com/0gfoundation/revm?rev=23e8e45813af0832e398544e60d51ffc65b09070#23e8e45813af0832e398544e60d51ffc65b09070"
+source = "git+https://github.com/0gfoundation/revm?rev=a7b0699dd52ac33e9e5f4b8e9165157a72d80d91#a7b0699dd52ac33e9e5f4b8e9165157a72d80d91"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -11050,7 +11050,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "10.2.0"
-source = "git+https://github.com/0gfoundation/revm?rev=23e8e45813af0832e398544e60d51ffc65b09070#23e8e45813af0832e398544e60d51ffc65b09070"
+source = "git+https://github.com/0gfoundation/revm?rev=a7b0699dd52ac33e9e5f4b8e9165157a72d80d91#a7b0699dd52ac33e9e5f4b8e9165157a72d80d91"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -11065,7 +11065,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "7.0.5"
-source = "git+https://github.com/0gfoundation/revm?rev=23e8e45813af0832e398544e60d51ffc65b09070#23e8e45813af0832e398544e60d51ffc65b09070"
+source = "git+https://github.com/0gfoundation/revm?rev=a7b0699dd52ac33e9e5f4b8e9165157a72d80d91#a7b0699dd52ac33e9e5f4b8e9165157a72d80d91"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -11078,7 +11078,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "7.0.5"
-source = "git+https://github.com/0gfoundation/revm?rev=23e8e45813af0832e398544e60d51ffc65b09070#23e8e45813af0832e398544e60d51ffc65b09070"
+source = "git+https://github.com/0gfoundation/revm?rev=a7b0699dd52ac33e9e5f4b8e9165157a72d80d91#a7b0699dd52ac33e9e5f4b8e9165157a72d80d91"
 dependencies = [
  "auto_impl",
  "either",
@@ -11090,7 +11090,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "10.0.1"
-source = "git+https://github.com/0gfoundation/revm?rev=23e8e45813af0832e398544e60d51ffc65b09070#23e8e45813af0832e398544e60d51ffc65b09070"
+source = "git+https://github.com/0gfoundation/revm?rev=a7b0699dd52ac33e9e5f4b8e9165157a72d80d91#a7b0699dd52ac33e9e5f4b8e9165157a72d80d91"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -11108,7 +11108,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "10.0.1"
-source = "git+https://github.com/0gfoundation/revm?rev=23e8e45813af0832e398544e60d51ffc65b09070#23e8e45813af0832e398544e60d51ffc65b09070"
+source = "git+https://github.com/0gfoundation/revm?rev=a7b0699dd52ac33e9e5f4b8e9165157a72d80d91#a7b0699dd52ac33e9e5f4b8e9165157a72d80d91"
 dependencies = [
  "auto_impl",
  "either",
@@ -11145,7 +11145,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "25.0.3"
-source = "git+https://github.com/0gfoundation/revm?rev=23e8e45813af0832e398544e60d51ffc65b09070#23e8e45813af0832e398544e60d51ffc65b09070"
+source = "git+https://github.com/0gfoundation/revm?rev=a7b0699dd52ac33e9e5f4b8e9165157a72d80d91#a7b0699dd52ac33e9e5f4b8e9165157a72d80d91"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -11156,7 +11156,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "27.0.0"
-source = "git+https://github.com/0gfoundation/revm?rev=23e8e45813af0832e398544e60d51ffc65b09070#23e8e45813af0832e398544e60d51ffc65b09070"
+source = "git+https://github.com/0gfoundation/revm?rev=a7b0699dd52ac33e9e5f4b8e9165157a72d80d91#a7b0699dd52ac33e9e5f4b8e9165157a72d80d91"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -11188,7 +11188,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "20.2.1"
-source = "git+https://github.com/0gfoundation/revm?rev=23e8e45813af0832e398544e60d51ffc65b09070#23e8e45813af0832e398544e60d51ffc65b09070"
+source = "git+https://github.com/0gfoundation/revm?rev=a7b0699dd52ac33e9e5f4b8e9165157a72d80d91#a7b0699dd52ac33e9e5f4b8e9165157a72d80d91"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -11199,7 +11199,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "7.0.5"
-source = "git+https://github.com/0gfoundation/revm?rev=23e8e45813af0832e398544e60d51ffc65b09070#23e8e45813af0832e398544e60d51ffc65b09070"
+source = "git+https://github.com/0gfoundation/revm?rev=a7b0699dd52ac33e9e5f4b8e9165157a72d80d91#a7b0699dd52ac33e9e5f4b8e9165157a72d80d91"
 dependencies = [
  "bitflags 2.11.1",
  "revm-bytecode",
@@ -11454,7 +11454,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12344,7 +12344,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13572,7 +13572,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -965,7 +965,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2990,7 +2990,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3280,7 +3280,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4600,7 +4600,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -5052,7 +5052,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6042,7 +6042,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6319,7 +6319,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "10.1.0"
-source = "git+https://github.com/0gfoundation/revm?rev=d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb#d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb"
+source = "git+https://github.com/0gfoundation/revm?rev=23e8e45813af0832e398544e60d51ffc65b09070#23e8e45813af0832e398544e60d51ffc65b09070"
 dependencies = [
  "auto_impl",
  "revm",
@@ -11005,7 +11005,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "29.0.1"
-source = "git+https://github.com/0gfoundation/revm?rev=d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb#d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb"
+source = "git+https://github.com/0gfoundation/revm?rev=23e8e45813af0832e398544e60d51ffc65b09070#23e8e45813af0832e398544e60d51ffc65b09070"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -11023,7 +11023,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "6.2.2"
-source = "git+https://github.com/0gfoundation/revm?rev=d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb#d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb"
+source = "git+https://github.com/0gfoundation/revm?rev=23e8e45813af0832e398544e60d51ffc65b09070#23e8e45813af0832e398544e60d51ffc65b09070"
 dependencies = [
  "bitvec",
  "phf",
@@ -11034,7 +11034,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "9.1.0"
-source = "git+https://github.com/0gfoundation/revm?rev=d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb#d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb"
+source = "git+https://github.com/0gfoundation/revm?rev=23e8e45813af0832e398544e60d51ffc65b09070#23e8e45813af0832e398544e60d51ffc65b09070"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -11050,7 +11050,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "10.2.0"
-source = "git+https://github.com/0gfoundation/revm?rev=d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb#d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb"
+source = "git+https://github.com/0gfoundation/revm?rev=23e8e45813af0832e398544e60d51ffc65b09070#23e8e45813af0832e398544e60d51ffc65b09070"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -11065,7 +11065,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "7.0.5"
-source = "git+https://github.com/0gfoundation/revm?rev=d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb#d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb"
+source = "git+https://github.com/0gfoundation/revm?rev=23e8e45813af0832e398544e60d51ffc65b09070#23e8e45813af0832e398544e60d51ffc65b09070"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -11078,7 +11078,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "7.0.5"
-source = "git+https://github.com/0gfoundation/revm?rev=d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb#d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb"
+source = "git+https://github.com/0gfoundation/revm?rev=23e8e45813af0832e398544e60d51ffc65b09070#23e8e45813af0832e398544e60d51ffc65b09070"
 dependencies = [
  "auto_impl",
  "either",
@@ -11090,7 +11090,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "10.0.1"
-source = "git+https://github.com/0gfoundation/revm?rev=d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb#d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb"
+source = "git+https://github.com/0gfoundation/revm?rev=23e8e45813af0832e398544e60d51ffc65b09070#23e8e45813af0832e398544e60d51ffc65b09070"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -11108,7 +11108,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "10.0.1"
-source = "git+https://github.com/0gfoundation/revm?rev=d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb#d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb"
+source = "git+https://github.com/0gfoundation/revm?rev=23e8e45813af0832e398544e60d51ffc65b09070#23e8e45813af0832e398544e60d51ffc65b09070"
 dependencies = [
  "auto_impl",
  "either",
@@ -11145,7 +11145,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "25.0.3"
-source = "git+https://github.com/0gfoundation/revm?rev=d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb#d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb"
+source = "git+https://github.com/0gfoundation/revm?rev=23e8e45813af0832e398544e60d51ffc65b09070#23e8e45813af0832e398544e60d51ffc65b09070"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -11156,7 +11156,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "27.0.0"
-source = "git+https://github.com/0gfoundation/revm?rev=d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb#d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb"
+source = "git+https://github.com/0gfoundation/revm?rev=23e8e45813af0832e398544e60d51ffc65b09070#23e8e45813af0832e398544e60d51ffc65b09070"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -11188,7 +11188,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "20.2.1"
-source = "git+https://github.com/0gfoundation/revm?rev=d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb#d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb"
+source = "git+https://github.com/0gfoundation/revm?rev=23e8e45813af0832e398544e60d51ffc65b09070#23e8e45813af0832e398544e60d51ffc65b09070"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -11199,7 +11199,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "7.0.5"
-source = "git+https://github.com/0gfoundation/revm?rev=d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb#d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb"
+source = "git+https://github.com/0gfoundation/revm?rev=23e8e45813af0832e398544e60d51ffc65b09070#23e8e45813af0832e398544e60d51ffc65b09070"
 dependencies = [
  "bitflags 2.11.1",
  "revm-bytecode",
@@ -11454,7 +11454,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12116,7 +12116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12344,7 +12344,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13572,7 +13572,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.21.3"
+source = "git+https://github.com/0gfoundation/alloy-evm?rev=856b180aa66cd64e6f08f1621f3e3270da4cfb2d#856b180aa66cd64e6f08f1621f3e3270da4cfb2d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -953,7 +954,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -964,7 +965,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2277,7 +2278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2989,7 +2990,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3279,7 +3280,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4599,7 +4600,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5051,7 +5052,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6041,7 +6042,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6318,6 +6319,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "10.1.0"
+source = "git+https://github.com/0gfoundation/revm?rev=d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb#d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb"
 dependencies = [
  "auto_impl",
  "revm",
@@ -11004,6 +11006,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "29.0.1"
+source = "git+https://github.com/0gfoundation/revm?rev=d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb#d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -11021,6 +11024,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "6.2.2"
+source = "git+https://github.com/0gfoundation/revm?rev=d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb#d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb"
 dependencies = [
  "bitvec",
  "phf",
@@ -11031,6 +11035,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "9.1.0"
+source = "git+https://github.com/0gfoundation/revm?rev=d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb#d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -11046,6 +11051,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "10.2.0"
+source = "git+https://github.com/0gfoundation/revm?rev=d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb#d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -11060,6 +11066,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "7.0.5"
+source = "git+https://github.com/0gfoundation/revm?rev=d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb#d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -11072,6 +11079,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "7.0.5"
+source = "git+https://github.com/0gfoundation/revm?rev=d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb#d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb"
 dependencies = [
  "auto_impl",
  "either",
@@ -11083,6 +11091,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "10.0.1"
+source = "git+https://github.com/0gfoundation/revm?rev=d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb#d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -11100,6 +11109,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "10.0.1"
+source = "git+https://github.com/0gfoundation/revm?rev=d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb#d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb"
 dependencies = [
  "auto_impl",
  "either",
@@ -11136,6 +11146,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "25.0.3"
+source = "git+https://github.com/0gfoundation/revm?rev=d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb#d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -11146,6 +11157,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "27.0.0"
+source = "git+https://github.com/0gfoundation/revm?rev=d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb#d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -11177,6 +11189,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "20.2.1"
+source = "git+https://github.com/0gfoundation/revm?rev=d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb#d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -11187,6 +11200,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "7.0.5"
+source = "git+https://github.com/0gfoundation/revm?rev=d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb#d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb"
 dependencies = [
  "bitflags 2.11.1",
  "revm-bytecode",
@@ -11428,7 +11442,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11441,7 +11455,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11499,7 +11513,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12103,7 +12117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12331,7 +12345,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13559,7 +13573,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -714,22 +714,21 @@ walkdir = "2.3.3"
 vergen-git2 = "=1.0.5"
 
 [patch.crates-io]
-# PerpState dev: revm + alloy-evm point at local sibling checkouts (working tree, incl. uncommitted
-# Phase-1 perp journal API). Restore the git-rev pins (revm 9bbdc91b, alloy-evm d9253fe) before
-# CI / teammate builds.
-revm = { path = "../revm/crates/revm" }
-revm-bytecode = { path = "../revm/crates/bytecode", package = "revm-bytecode" }
-revm-database = { path = "../revm/crates/database", package = "revm-database" }
-revm-state = { path = "../revm/crates/state", package = "revm-state" }
-revm-primitives = { path = "../revm/crates/primitives", package = "revm-primitives" }
-revm-interpreter = { path = "../revm/crates/interpreter", package = "revm-interpreter" }
-revm-inspector = { path = "../revm/crates/inspector", package = "revm-inspector" }
-revm-context = { path = "../revm/crates/context", package = "revm-context" }
-revm-context-interface = { path = "../revm/crates/context/interface", package = "revm-context-interface" }
-revm-database-interface = { path = "../revm/crates/database/interface", package = "revm-database-interface" }
-op-revm = { path = "../revm/crates/op-revm", package = "op-revm" }
+# PerpState: revm-* + op-revm pinned at revm perpstate-journal HEAD (off-trie perp journal API);
+# alloy-evm pinned at its perpstate-journal HEAD (Evm::take_perp_delta harvest hook).
+revm = { git = "https://github.com/0gfoundation/revm", rev = "d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb" }
+revm-bytecode = { git = "https://github.com/0gfoundation/revm", rev = "d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb", package = "revm-bytecode" }
+revm-database = { git = "https://github.com/0gfoundation/revm", rev = "d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb", package = "revm-database" }
+revm-state = { git = "https://github.com/0gfoundation/revm", rev = "d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb", package = "revm-state" }
+revm-primitives = { git = "https://github.com/0gfoundation/revm", rev = "d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb", package = "revm-primitives" }
+revm-interpreter = { git = "https://github.com/0gfoundation/revm", rev = "d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb", package = "revm-interpreter" }
+revm-inspector = { git = "https://github.com/0gfoundation/revm", rev = "d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb", package = "revm-inspector" }
+revm-context = { git = "https://github.com/0gfoundation/revm", rev = "d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb", package = "revm-context" }
+revm-context-interface = { git = "https://github.com/0gfoundation/revm", rev = "d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb", package = "revm-context-interface" }
+revm-database-interface = { git = "https://github.com/0gfoundation/revm", rev = "d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb", package = "revm-database-interface" }
+op-revm = { git = "https://github.com/0gfoundation/revm", rev = "d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb", package = "op-revm" }
 
-alloy-evm = { path = "../alloy-evm/crates/evm" }
+alloy-evm = { git = "https://github.com/0gfoundation/alloy-evm", rev = "856b180aa66cd64e6f08f1621f3e3270da4cfb2d", package = "alloy-evm" }
 
 # Patch alloy 1.0.35 with 0g-alloy
 alloy-consensus = { git = "https://github.com/0gfoundation/0g-alloy", rev = "54d1e2d3fbf71a7bdb8bc802e538e3c63b1e2e03", package = "alloy-consensus" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -716,17 +716,17 @@ vergen-git2 = "=1.0.5"
 [patch.crates-io]
 # PerpState: revm-* + op-revm pinned at revm perpstate-journal HEAD (off-trie perp journal API);
 # alloy-evm pinned at its perpstate-journal HEAD (Evm::take_perp_delta harvest hook).
-revm = { git = "https://github.com/0gfoundation/revm", rev = "d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb" }
-revm-bytecode = { git = "https://github.com/0gfoundation/revm", rev = "d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb", package = "revm-bytecode" }
-revm-database = { git = "https://github.com/0gfoundation/revm", rev = "d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb", package = "revm-database" }
-revm-state = { git = "https://github.com/0gfoundation/revm", rev = "d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb", package = "revm-state" }
-revm-primitives = { git = "https://github.com/0gfoundation/revm", rev = "d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb", package = "revm-primitives" }
-revm-interpreter = { git = "https://github.com/0gfoundation/revm", rev = "d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb", package = "revm-interpreter" }
-revm-inspector = { git = "https://github.com/0gfoundation/revm", rev = "d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb", package = "revm-inspector" }
-revm-context = { git = "https://github.com/0gfoundation/revm", rev = "d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb", package = "revm-context" }
-revm-context-interface = { git = "https://github.com/0gfoundation/revm", rev = "d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb", package = "revm-context-interface" }
-revm-database-interface = { git = "https://github.com/0gfoundation/revm", rev = "d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb", package = "revm-database-interface" }
-op-revm = { git = "https://github.com/0gfoundation/revm", rev = "d3c8480c2bb6ff447366e2d2ff37c8accb0db4bb", package = "op-revm" }
+revm = { git = "https://github.com/0gfoundation/revm", rev = "23e8e45813af0832e398544e60d51ffc65b09070" }
+revm-bytecode = { git = "https://github.com/0gfoundation/revm", rev = "23e8e45813af0832e398544e60d51ffc65b09070", package = "revm-bytecode" }
+revm-database = { git = "https://github.com/0gfoundation/revm", rev = "23e8e45813af0832e398544e60d51ffc65b09070", package = "revm-database" }
+revm-state = { git = "https://github.com/0gfoundation/revm", rev = "23e8e45813af0832e398544e60d51ffc65b09070", package = "revm-state" }
+revm-primitives = { git = "https://github.com/0gfoundation/revm", rev = "23e8e45813af0832e398544e60d51ffc65b09070", package = "revm-primitives" }
+revm-interpreter = { git = "https://github.com/0gfoundation/revm", rev = "23e8e45813af0832e398544e60d51ffc65b09070", package = "revm-interpreter" }
+revm-inspector = { git = "https://github.com/0gfoundation/revm", rev = "23e8e45813af0832e398544e60d51ffc65b09070", package = "revm-inspector" }
+revm-context = { git = "https://github.com/0gfoundation/revm", rev = "23e8e45813af0832e398544e60d51ffc65b09070", package = "revm-context" }
+revm-context-interface = { git = "https://github.com/0gfoundation/revm", rev = "23e8e45813af0832e398544e60d51ffc65b09070", package = "revm-context-interface" }
+revm-database-interface = { git = "https://github.com/0gfoundation/revm", rev = "23e8e45813af0832e398544e60d51ffc65b09070", package = "revm-database-interface" }
+op-revm = { git = "https://github.com/0gfoundation/revm", rev = "23e8e45813af0832e398544e60d51ffc65b09070", package = "op-revm" }
 
 alloy-evm = { git = "https://github.com/0gfoundation/alloy-evm", rev = "856b180aa66cd64e6f08f1621f3e3270da4cfb2d", package = "alloy-evm" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -714,19 +714,22 @@ walkdir = "2.3.3"
 vergen-git2 = "=1.0.5"
 
 [patch.crates-io]
-revm = { git = "https://github.com/0gfoundation/revm", rev = "9bbdc91b26d41494b7870b2475e1ed4727eff8fc" }
-revm-bytecode = { git = "https://github.com/0gfoundation/revm", rev = "9bbdc91b26d41494b7870b2475e1ed4727eff8fc", package = "revm-bytecode" }
-revm-database = { git = "https://github.com/0gfoundation/revm", rev = "9bbdc91b26d41494b7870b2475e1ed4727eff8fc", package = "revm-database" }
-revm-state = { git = "https://github.com/0gfoundation/revm", rev = "9bbdc91b26d41494b7870b2475e1ed4727eff8fc", package = "revm-state" }
-revm-primitives = { git = "https://github.com/0gfoundation/revm", rev = "9bbdc91b26d41494b7870b2475e1ed4727eff8fc", package = "revm-primitives" }
-revm-interpreter = { git = "https://github.com/0gfoundation/revm", rev = "9bbdc91b26d41494b7870b2475e1ed4727eff8fc", package = "revm-interpreter" }
-revm-inspector = { git = "https://github.com/0gfoundation/revm", rev = "9bbdc91b26d41494b7870b2475e1ed4727eff8fc", package = "revm-inspector" }
-revm-context = { git = "https://github.com/0gfoundation/revm", rev = "9bbdc91b26d41494b7870b2475e1ed4727eff8fc", package = "revm-context" }
-revm-context-interface = { git = "https://github.com/0gfoundation/revm", rev = "9bbdc91b26d41494b7870b2475e1ed4727eff8fc", package = "revm-context-interface" }
-revm-database-interface = { git = "https://github.com/0gfoundation/revm", rev = "9bbdc91b26d41494b7870b2475e1ed4727eff8fc", package = "revm-database-interface" }
-op-revm = { git = "https://github.com/0gfoundation/revm", rev = "9bbdc91b26d41494b7870b2475e1ed4727eff8fc", package = "op-revm" }
+# PerpState dev: revm + alloy-evm point at local sibling checkouts (working tree, incl. uncommitted
+# Phase-1 perp journal API). Restore the git-rev pins (revm 9bbdc91b, alloy-evm d9253fe) before
+# CI / teammate builds.
+revm = { path = "../revm/crates/revm" }
+revm-bytecode = { path = "../revm/crates/bytecode", package = "revm-bytecode" }
+revm-database = { path = "../revm/crates/database", package = "revm-database" }
+revm-state = { path = "../revm/crates/state", package = "revm-state" }
+revm-primitives = { path = "../revm/crates/primitives", package = "revm-primitives" }
+revm-interpreter = { path = "../revm/crates/interpreter", package = "revm-interpreter" }
+revm-inspector = { path = "../revm/crates/inspector", package = "revm-inspector" }
+revm-context = { path = "../revm/crates/context", package = "revm-context" }
+revm-context-interface = { path = "../revm/crates/context/interface", package = "revm-context-interface" }
+revm-database-interface = { path = "../revm/crates/database/interface", package = "revm-database-interface" }
+op-revm = { path = "../revm/crates/op-revm", package = "op-revm" }
 
-alloy-evm = { git = "https://github.com/0gfoundation/alloy-evm", rev = "d9253fe11c5c9d229231df15bfd928619ee53c08" }
+alloy-evm = { path = "../alloy-evm/crates/evm" }
 
 # Patch alloy 1.0.35 with 0g-alloy
 alloy-consensus = { git = "https://github.com/0gfoundation/0g-alloy", rev = "54d1e2d3fbf71a7bdb8bc802e538e3c63b1e2e03", package = "alloy-consensus" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -716,17 +716,17 @@ vergen-git2 = "=1.0.5"
 [patch.crates-io]
 # PerpState: revm-* + op-revm pinned at revm perpstate-journal HEAD (off-trie perp journal API);
 # alloy-evm pinned at its perpstate-journal HEAD (Evm::take_perp_delta harvest hook).
-revm = { git = "https://github.com/0gfoundation/revm", rev = "23e8e45813af0832e398544e60d51ffc65b09070" }
-revm-bytecode = { git = "https://github.com/0gfoundation/revm", rev = "23e8e45813af0832e398544e60d51ffc65b09070", package = "revm-bytecode" }
-revm-database = { git = "https://github.com/0gfoundation/revm", rev = "23e8e45813af0832e398544e60d51ffc65b09070", package = "revm-database" }
-revm-state = { git = "https://github.com/0gfoundation/revm", rev = "23e8e45813af0832e398544e60d51ffc65b09070", package = "revm-state" }
-revm-primitives = { git = "https://github.com/0gfoundation/revm", rev = "23e8e45813af0832e398544e60d51ffc65b09070", package = "revm-primitives" }
-revm-interpreter = { git = "https://github.com/0gfoundation/revm", rev = "23e8e45813af0832e398544e60d51ffc65b09070", package = "revm-interpreter" }
-revm-inspector = { git = "https://github.com/0gfoundation/revm", rev = "23e8e45813af0832e398544e60d51ffc65b09070", package = "revm-inspector" }
-revm-context = { git = "https://github.com/0gfoundation/revm", rev = "23e8e45813af0832e398544e60d51ffc65b09070", package = "revm-context" }
-revm-context-interface = { git = "https://github.com/0gfoundation/revm", rev = "23e8e45813af0832e398544e60d51ffc65b09070", package = "revm-context-interface" }
-revm-database-interface = { git = "https://github.com/0gfoundation/revm", rev = "23e8e45813af0832e398544e60d51ffc65b09070", package = "revm-database-interface" }
-op-revm = { git = "https://github.com/0gfoundation/revm", rev = "23e8e45813af0832e398544e60d51ffc65b09070", package = "op-revm" }
+revm = { git = "https://github.com/0gfoundation/revm", rev = "a7b0699dd52ac33e9e5f4b8e9165157a72d80d91" }
+revm-bytecode = { git = "https://github.com/0gfoundation/revm", rev = "a7b0699dd52ac33e9e5f4b8e9165157a72d80d91", package = "revm-bytecode" }
+revm-database = { git = "https://github.com/0gfoundation/revm", rev = "a7b0699dd52ac33e9e5f4b8e9165157a72d80d91", package = "revm-database" }
+revm-state = { git = "https://github.com/0gfoundation/revm", rev = "a7b0699dd52ac33e9e5f4b8e9165157a72d80d91", package = "revm-state" }
+revm-primitives = { git = "https://github.com/0gfoundation/revm", rev = "a7b0699dd52ac33e9e5f4b8e9165157a72d80d91", package = "revm-primitives" }
+revm-interpreter = { git = "https://github.com/0gfoundation/revm", rev = "a7b0699dd52ac33e9e5f4b8e9165157a72d80d91", package = "revm-interpreter" }
+revm-inspector = { git = "https://github.com/0gfoundation/revm", rev = "a7b0699dd52ac33e9e5f4b8e9165157a72d80d91", package = "revm-inspector" }
+revm-context = { git = "https://github.com/0gfoundation/revm", rev = "a7b0699dd52ac33e9e5f4b8e9165157a72d80d91", package = "revm-context" }
+revm-context-interface = { git = "https://github.com/0gfoundation/revm", rev = "a7b0699dd52ac33e9e5f4b8e9165157a72d80d91", package = "revm-context-interface" }
+revm-database-interface = { git = "https://github.com/0gfoundation/revm", rev = "a7b0699dd52ac33e9e5f4b8e9165157a72d80d91", package = "revm-database-interface" }
+op-revm = { git = "https://github.com/0gfoundation/revm", rev = "a7b0699dd52ac33e9e5f4b8e9165157a72d80d91", package = "op-revm" }
 
 alloy-evm = { git = "https://github.com/0gfoundation/alloy-evm", rev = "856b180aa66cd64e6f08f1621f3e3270da4cfb2d", package = "alloy-evm" }
 

--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -141,6 +141,12 @@ pub(crate) struct CanonicalInMemoryStateInner<N: NodePrimitives> {
     pub(crate) in_memory_state: InMemoryState<N>,
     /// A broadcast stream that emits events when the canonical chain is updated.
     pub(crate) canon_state_notification_sender: CanonStateNotificationSender<N>,
+    /// Off-trie PerpDEX canonical store ("PerpState"): committed orderbook blobs keyed by
+    /// domain key. Written only when a block enters the canonical chain (see
+    /// [`CanonicalInMemoryState::merge_perp_delta`]); read by the EVM cold-read path. An empty
+    /// value means the key is absent. Shared by every clone of [`CanonicalInMemoryState`] via
+    /// the surrounding `Arc`.
+    pub(crate) canonical_perp: Arc<RwLock<HashMap<B256, Vec<u8>>>>,
 }
 
 impl<N: NodePrimitives> CanonicalInMemoryStateInner<N> {
@@ -194,6 +200,7 @@ impl<N: NodePrimitives> CanonicalInMemoryState<N> {
                 chain_info_tracker,
                 in_memory_state,
                 canon_state_notification_sender,
+                canonical_perp: Default::default(),
             }),
         }
     }
@@ -218,9 +225,36 @@ impl<N: NodePrimitives> CanonicalInMemoryState<N> {
             chain_info_tracker,
             in_memory_state,
             canon_state_notification_sender,
+            canonical_perp: Default::default(),
         };
 
         Self { inner: Arc::new(inner) }
+    }
+
+    /// Returns a cloneable handle to the off-trie PerpDEX canonical store ("PerpState").
+    ///
+    /// The same `Arc` is shared by every clone of this state (provider, engine tree, RPC), so
+    /// this is also the read handle the EVM cold-read path uses.
+    pub fn canonical_perp(&self) -> Arc<RwLock<HashMap<B256, Vec<u8>>>> {
+        self.inner.canonical_perp.clone()
+    }
+
+    /// Merges a block's net off-trie PerpDEX writes ("PerpState") into the canonical store.
+    ///
+    /// An empty value deletes the key. Called when a block enters the canonical chain. No-op for
+    /// an empty delta.
+    pub fn merge_perp_delta(&self, delta: &HashMap<B256, Vec<u8>>) {
+        if delta.is_empty() {
+            return;
+        }
+        let mut store = self.inner.canonical_perp.write();
+        for (key, value) in delta {
+            if value.is_empty() {
+                store.remove(key);
+            } else {
+                store.insert(*key, value.clone());
+            }
+        }
     }
 
     /// Returns the block hash corresponding to the given number.
@@ -979,6 +1013,28 @@ mod tests {
         AccountProof, HashedStorage, MultiProof, MultiProofTargets, StorageMultiProof,
         StorageProof, TrieInput,
     };
+
+    #[test]
+    fn merge_perp_delta_inserts_and_deletes() {
+        let state = CanonicalInMemoryState::<EthPrimitives>::empty();
+        let key = B256::repeat_byte(7);
+
+        // A non-empty value inserts/overwrites.
+        let mut delta = HashMap::default();
+        delta.insert(key, vec![1u8, 2, 3]);
+        state.merge_perp_delta(&delta);
+        assert_eq!(state.canonical_perp().read().get(&key), Some(&vec![1u8, 2, 3]));
+
+        // An empty value deletes the key.
+        let mut delete = HashMap::default();
+        delete.insert(key, Vec::new());
+        state.merge_perp_delta(&delete);
+        assert!(state.canonical_perp().read().get(&key).is_none());
+
+        // An empty delta is a no-op.
+        state.merge_perp_delta(&HashMap::default());
+        assert!(state.canonical_perp().read().is_empty());
+    }
 
     fn create_mock_state(
         test_block_builder: &mut TestBlockBuilder<EthPrimitives>,

--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -272,6 +272,14 @@ impl<N: NodePrimitives> CanonicalInMemoryState<N> {
         }
     }
 
+    /// Replaces the entire off-trie PerpDEX store with `map`. Called ONCE at node startup to
+    /// seed `canonical_perp` from the durable `PerpState` table (state as of the persisted
+    /// head); the unpersisted tail is then rebuilt by re-executing re-fed blocks. Unlike
+    /// [`Self::merge_perp_delta`] this overwrites rather than merges.
+    pub fn seed_perp(&self, map: HashMap<B256, Vec<u8>>) {
+        *self.inner.canonical_perp.write() = map;
+    }
+
     /// Returns the block hash corresponding to the given number.
     pub fn hash_by_number(&self, number: u64) -> Option<B256> {
         self.inner.in_memory_state.hash_by_number(number)
@@ -1049,6 +1057,25 @@ mod tests {
         // An empty delta is a no-op.
         state.merge_perp_delta(&HashMap::default());
         assert!(state.canonical_perp().read().is_empty());
+    }
+
+    #[test]
+    fn seed_perp_replaces_whole_map() {
+        let state = CanonicalInMemoryState::<EthPrimitives>::empty();
+        // pre-existing junk that seed must clear:
+        state.merge_perp_delta(&HashMap::from_iter([(B256::with_last_byte(9), vec![0xFF])]));
+
+        let mut snapshot = HashMap::default();
+        snapshot.insert(B256::with_last_byte(1), vec![0xAA]);
+        snapshot.insert(B256::with_last_byte(2), vec![0xBB]);
+        state.seed_perp(snapshot);
+
+        let store = state.canonical_perp();
+        let g = store.read();
+        assert_eq!(g.get(&B256::with_last_byte(1)), Some(&vec![0xAAu8]));
+        assert_eq!(g.get(&B256::with_last_byte(2)), Some(&vec![0xBBu8]));
+        assert!(g.get(&B256::with_last_byte(9)).is_none()); // replaced, not merged
+        assert_eq!(g.len(), 2);
     }
 
     #[test]

--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -16,7 +16,7 @@ use reth_primitives_traits::{
     BlockBody as _, IndexedTx, NodePrimitives, RecoveredBlock, SealedBlock, SealedHeader,
     SignedTransaction,
 };
-use reth_storage_api::StateProviderBox;
+use reth_storage_api::{PerpHandle, PerpStateHandle, StateProviderBox};
 use reth_trie::{updates::TrieUpdates, HashedPostState};
 use std::{collections::BTreeMap, sync::Arc, time::Instant};
 use tokio::sync::{broadcast, watch};
@@ -166,6 +166,16 @@ impl<N: NodePrimitives> CanonicalInMemoryStateInner<N> {
     }
 }
 
+/// 把共享的 `canonical_perp` map 适配成 [`PerpStateHandle`] 读句柄。
+#[derive(Debug, Clone)]
+struct PerpStore(Arc<RwLock<HashMap<B256, Vec<u8>>>>);
+
+impl PerpStateHandle for PerpStore {
+    fn perp_get(&self, key: B256) -> Vec<u8> {
+        self.0.read().get(&key).cloned().unwrap_or_default()
+    }
+}
+
 type PendingBlockAndReceipts<N> =
     (RecoveredBlock<<N as NodePrimitives>::Block>, Vec<reth_primitives_traits::ReceiptTy<N>>);
 
@@ -237,6 +247,11 @@ impl<N: NodePrimitives> CanonicalInMemoryState<N> {
     /// this is also the read handle the EVM cold-read path uses.
     pub fn canonical_perp(&self) -> Arc<RwLock<HashMap<B256, Vec<u8>>>> {
         self.inner.canonical_perp.clone()
+    }
+
+    /// 返回 off-trie PerpDEX 存储的 [`PerpStateHandle`] 读句柄，供 EVM 冷读路径(共识 + RPC)使用。
+    pub fn canonical_perp_handle(&self) -> PerpHandle {
+        Arc::new(PerpStore(self.inner.canonical_perp.clone()))
     }
 
     /// Merges a block's net off-trie PerpDEX writes ("PerpState") into the canonical store.
@@ -1034,6 +1049,19 @@ mod tests {
         // An empty delta is a no-op.
         state.merge_perp_delta(&HashMap::default());
         assert!(state.canonical_perp().read().is_empty());
+    }
+
+    #[test]
+    fn canonical_perp_handle_reads_committed_value() {
+        let state = CanonicalInMemoryState::<EthPrimitives>::empty();
+        let key = B256::with_last_byte(7);
+        let mut delta = HashMap::default();
+        delta.insert(key, vec![9u8, 9]);
+        state.merge_perp_delta(&delta);
+
+        let handle = state.canonical_perp_handle();
+        assert_eq!(handle.perp_get(key), vec![9u8, 9]);
+        assert!(handle.perp_get(B256::with_last_byte(8)).is_empty());
     }
 
     fn create_mock_state(

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -27,7 +27,8 @@ reth-primitives-traits.workspace = true
 reth-ethereum-primitives.workspace = true
 reth-provider.workspace = true
 reth-prune.workspace = true
-reth-revm.workspace = true
+# `std` enables `PerpDb` (off-trie PerpState cold-read wrapper); engine-tree is std-only.
+reth-revm = { workspace = true, features = ["std"] }
 reth-stages-api.workspace = true
 reth-tasks.workspace = true
 reth-trie-db.workspace = true

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -126,6 +126,12 @@ where
         new_tip_num: u64,
     ) -> Result<Option<BlockNumHash>, PersistenceError> {
         debug!(target: "engine::persistence", ?new_tip_num, "Removing blocks");
+        tracing::warn!(
+            target: "engine::persistence",
+            "RemoveBlocksAbove fired: PerpState table is NOT rolled back here. If a real reorg \
+             occurred, the off-trie perp store may now be inconsistent with the canonical chain \
+             (reorg support for perp is out of scope; single-node/no-reorg assumption)."
+        );
         let start_time = Instant::now();
         let provider_rw = self.provider.database_provider_rw()?;
         let sf_provider = self.provider.static_file_provider();
@@ -151,10 +157,21 @@ where
         });
 
         if last_block_hash_num.is_some() {
+            // Harvest each block's off-trie PerpDEX delta BEFORE `blocks` is moved into save_blocks.
+            let perp_deltas: Vec<alloy_primitives::map::HashMap<alloy_primitives::B256, Vec<u8>>> =
+                blocks.iter().filter_map(|b| b.block.execution_output.perp.clone()).collect();
+
             let provider_rw = self.provider.database_provider_rw()?;
             let static_file_provider = self.provider.static_file_provider();
 
             UnifiedStorageWriter::from(&provider_rw, &static_file_provider).save_blocks(blocks)?;
+
+            // Apply the perp deltas in the SAME RW txn, so they commit atomically with block state.
+            // Order matters only for last-write-wins per key; block order is preserved here.
+            for delta in &perp_deltas {
+                provider_rw.write_perp_state_delta(delta)?;
+            }
+
             UnifiedStorageWriter::commit(provider_rw)?;
         }
         self.metrics.save_blocks_duration_seconds.record(start_time.elapsed());

--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -84,19 +84,26 @@ impl EngineApiMetrics {
                 trace!(target: "engine::tree", "Executing transaction");
                 executor.execute_transaction(tx)?;
             }
-            executor.finish().map(|(evm, result)| (evm.into_db(), result))
+            let (mut evm, result) = executor.finish()?;
+            // Harvest the off-trie PerpDEX delta ("PerpState") while the EVM/journal is still
+            // alive, before `into_db` consumes it and drops the journal.
+            let perp = evm.take_perp_delta();
+            // Pin the error type: the original tail returned `finish().map(..)` (a Result with a
+            // known error type); the explicit `Ok` here would otherwise leave it ambiguous.
+            Ok::<_, BlockExecutionError>((evm.into_db(), perp, result))
         };
 
         // Use metered to execute and track timing/gas metrics
-        let (mut db, result) = self.metered(|| {
+        let (mut db, perp, result) = self.metered(|| {
             let res = f();
-            let gas_used = res.as_ref().map(|r| r.1.gas_used).unwrap_or(0);
+            let gas_used = res.as_ref().map(|r| r.2.gas_used).unwrap_or(0);
             (gas_used, res)
         })?;
 
         // merge transitions into bundle state
         db.borrow_mut().merge_transitions(BundleRetention::Reverts);
-        let output = BlockExecutionOutput { result, state: db.borrow_mut().take_bundle() };
+        let output =
+            BlockExecutionOutput { result, state: db.borrow_mut().take_bundle(), perp: Some(perp) };
 
         // Update the metrics for the number of accounts, storage slots and bytecodes updated
         let accounts = output.state.state.len();

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2165,6 +2165,17 @@ where
             self.reinsert_reorged_blocks(old);
         }
 
+        // Merge each committed block's off-trie PerpDEX writes ("PerpState") into the canonical
+        // perp store before `chain_update` is consumed below. Commit-only: the single-node scope
+        // has no reorgs (see docs/perpstate-journal集成方案.md §8.1). Empty value = delete the key.
+        if let NewCanonicalChain::Commit { new } = &chain_update {
+            for block in new {
+                if let Some(delta) = &block.execution_output.perp {
+                    self.canonical_in_memory_state.merge_perp_delta(delta);
+                }
+            }
+        }
+
         // update the tracked in-memory state with the new chain
         self.canonical_in_memory_state.update_chain(chain_update);
         self.canonical_in_memory_state.set_canonical_head(tip.clone());

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -484,7 +484,7 @@ where
         );
 
         // Execute the block and handle any execution errors
-        let perp_handle = ctx.canonical_in_memory_state().canonical_perp();
+        let perp_handle = ctx.canonical_in_memory_state().canonical_perp_handle();
         let output = match if self.config.state_provider_metrics() {
             let state_provider = InstrumentedStateProvider::from_state_provider(&state_provider);
             let result =
@@ -730,7 +730,7 @@ where
         debug!(target: "engine::tree", "Executing block");
 
         let mut db = State::builder()
-            .with_database(PerpDb::new(StateProviderDatabase::new(&state_provider), perp))
+            .with_database(PerpDb::new(StateProviderDatabase::new(&state_provider), Some(perp)))
             .with_bundle_update()
             .without_state_clear()
             .build();

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -40,6 +40,7 @@ use reth_provider::{
     ProviderError, StateProvider, StateProviderFactory, StateReader, StateRootProvider,
 };
 use reth_revm::db::State;
+use reth_revm::database::{PerpDb, PerpHandle};
 use reth_trie::{updates::TrieUpdates, HashedPostState, KeccakKeyHasher, TrieInput};
 use reth_trie_db::DatabaseHashedPostState;
 use reth_trie_parallel::root::{ParallelStateRoot, ParallelStateRootError};
@@ -483,13 +484,15 @@ where
         );
 
         // Execute the block and handle any execution errors
+        let perp_handle = ctx.canonical_in_memory_state().canonical_perp();
         let output = match if self.config.state_provider_metrics() {
             let state_provider = InstrumentedStateProvider::from_state_provider(&state_provider);
-            let result = self.execute_block(&state_provider, env, &input, &mut handle);
+            let result =
+                self.execute_block(&state_provider, env, &input, &mut handle, perp_handle.clone());
             state_provider.record_total_latency();
             result
         } else {
-            self.execute_block(&state_provider, env, &input, &mut handle)
+            self.execute_block(&state_provider, env, &input, &mut handle, perp_handle)
         } {
             Ok(output) => output,
             Err(err) => return self.handle_execution_error(input, err, &parent_block),
@@ -709,6 +712,9 @@ where
         env: ExecutionEnv<Evm>,
         input: &BlockOrPayload<T>,
         handle: &mut PayloadHandle<impl ExecutableTxFor<Evm>, Err>,
+        // Off-trie PerpDEX ("PerpState") committed-store read handle; wraps the execution DB in
+        // `PerpDb` so the EVM's perp cold-read resolves to `canonical_perp` (off the state trie).
+        perp: PerpHandle,
     ) -> Result<BlockExecutionOutput<N::Receipt>, InsertBlockErrorKind>
     where
         S: StateProvider,
@@ -724,7 +730,7 @@ where
         debug!(target: "engine::tree", "Executing block");
 
         let mut db = State::builder()
-            .with_database(StateProviderDatabase::new(&state_provider))
+            .with_database(PerpDb::new(StateProviderDatabase::new(&state_provider), perp))
             .with_bundle_update()
             .without_state_clear()
             .build();

--- a/crates/ethereum/evm/src/test_utils.rs
+++ b/crates/ethereum/evm/src/test_utils.rs
@@ -117,7 +117,7 @@ impl<'a, DB: Database, I: Inspector<EthEvmContext<&'a mut State<DB>>>> BlockExec
         self,
     ) -> Result<(Self::Evm, BlockExecutionResult<Self::Receipt>), BlockExecutionError> {
         let Self { result, mut evm, .. } = self;
-        let ExecutionOutcome { bundle, receipts, requests, first_block: _ } = result;
+        let ExecutionOutcome { bundle, receipts, requests, first_block: _, .. } = result;
         let result = BlockExecutionResult {
             receipts: receipts.into_iter().flatten().collect(),
             requests: requests.into_iter().fold(Requests::default(), |mut reqs, req| {

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -65,7 +65,7 @@ pub trait Executor<DB: Database>: Sized {
     {
         let result = self.execute_one(block)?;
         let mut state = self.into_state();
-        Ok(BlockExecutionOutput { state: state.take_bundle(), result })
+        Ok(BlockExecutionOutput { state: state.take_bundle(), result, perp: None })
     }
 
     /// Executes multiple inputs in the batch, and returns an aggregated [`ExecutionOutcome`].
@@ -105,7 +105,7 @@ pub trait Executor<DB: Database>: Sized {
         let result = self.execute_one(block)?;
         let mut state = self.into_state();
         f(&state);
-        Ok(BlockExecutionOutput { state: state.take_bundle(), result })
+        Ok(BlockExecutionOutput { state: state.take_bundle(), result, perp: None })
     }
 
     /// Executes the EVM with the given input and accepts a state hook closure that is invoked with
@@ -120,7 +120,7 @@ pub trait Executor<DB: Database>: Sized {
     {
         let result = self.execute_one_with_state_hook(block, state_hook)?;
         let mut state = self.into_state();
-        Ok(BlockExecutionOutput { state: state.take_bundle(), result })
+        Ok(BlockExecutionOutput { state: state.take_bundle(), result, perp: None })
     }
 
     /// Consumes the executor and returns the [`State`] containing all state changes.

--- a/crates/evm/execution-types/src/chain.rs
+++ b/crates/evm/execution-types/src/chain.rs
@@ -733,6 +733,7 @@ mod tests {
             receipts,
             requests: vec![],
             first_block: 10,
+            perp: None,
         };
 
         // Create a Chain object with a BTreeMap of blocks mapped to their block numbers,
@@ -752,6 +753,7 @@ mod tests {
             receipts: vec![vec![receipt1]],
             requests: vec![],
             first_block: 10,
+            perp: None,
         };
 
         // Assert that the execution outcome at the first block contains only the first receipt

--- a/crates/evm/execution-types/src/execute.rs
+++ b/crates/evm/execution-types/src/execute.rs
@@ -1,3 +1,4 @@
+use revm::context_interface::journaled_state::PerpDelta;
 use revm::database::BundleState;
 
 pub use alloy_evm::block::BlockExecutionResult;
@@ -22,4 +23,7 @@ pub struct BlockExecutionOutput<T> {
     pub result: BlockExecutionResult<T>,
     /// The changed state of the block after execution.
     pub state: BundleState,
+    /// Net off-trie PerpDEX writes ("PerpState") harvested during block execution, if any.
+    /// Carried alongside `state` but deliberately NOT folded into the bundle / state trie.
+    pub perp: Option<PerpDelta>,
 }

--- a/crates/evm/execution-types/src/execution_outcome.rs
+++ b/crates/evm/execution-types/src/execution_outcome.rs
@@ -5,6 +5,7 @@ use alloy_primitives::{logs_bloom, map::HashMap, Address, BlockNumber, Bloom, Lo
 use reth_primitives_traits::{Account, Bytecode, Receipt, StorageEntry};
 use reth_trie_common::{HashedPostState, KeyHasher};
 use revm::{
+    context_interface::journaled_state::PerpDelta,
     database::{states::BundleState, BundleAccount},
     state::AccountInfo,
 };
@@ -59,6 +60,11 @@ pub struct ExecutionOutcome<T = reth_ethereum_primitives::Receipt> {
     /// A transaction may have zero or more requests, so the length of the inner vector is not
     /// guaranteed to be the same as the number of transactions.
     pub requests: Vec<Requests>,
+    /// Net off-trie PerpDEX writes ("PerpState") for the contained block(s), if any.
+    /// Kept in-memory only: skipped by serde so it never enters persisted / bincode state,
+    /// and never folded into `bundle` or the state trie. Empty value in the map = delete key.
+    #[cfg_attr(feature = "serde", serde(default, skip))]
+    pub perp: Option<PerpDelta>,
 }
 
 impl<T> Default for ExecutionOutcome<T> {
@@ -68,6 +74,7 @@ impl<T> Default for ExecutionOutcome<T> {
             receipts: Default::default(),
             first_block: Default::default(),
             requests: Default::default(),
+            perp: None,
         }
     }
 }
@@ -83,7 +90,7 @@ impl<T> ExecutionOutcome<T> {
         first_block: BlockNumber,
         requests: Vec<Requests>,
     ) -> Self {
-        Self { bundle, receipts, first_block, requests }
+        Self { bundle, receipts, first_block, requests, perp: None }
     }
 
     /// Creates a new `ExecutionOutcome` from initialization parameters.
@@ -125,7 +132,7 @@ impl<T> ExecutionOutcome<T> {
             contracts_init.into_iter().map(|(code_hash, bytecode)| (code_hash, bytecode.0)),
         );
 
-        Self { bundle, receipts, first_block, requests }
+        Self { bundle, receipts, first_block, requests, perp: None }
     }
 
     /// Creates a new `ExecutionOutcome` from a single block execution result.
@@ -135,6 +142,7 @@ impl<T> ExecutionOutcome<T> {
             receipts: vec![output.result.receipts],
             first_block: block_number,
             requests: vec![output.result.requests],
+            perp: output.perp,
         }
     }
 
@@ -144,7 +152,8 @@ impl<T> ExecutionOutcome<T> {
         bundle: BundleState,
         results: Vec<BlockExecutionResult<T>>,
     ) -> Self {
-        let mut value = Self { bundle, first_block, receipts: Vec::new(), requests: Vec::new() };
+        let mut value =
+            Self { bundle, first_block, receipts: Vec::new(), requests: Vec::new(), perp: None };
         for result in results {
             value.receipts.push(result.receipts);
             value.requests.push(result.requests);
@@ -472,6 +481,8 @@ pub(super) mod serde_bincode_compat {
                     .collect(),
                 first_block: value.first_block,
                 requests: value.requests.into_owned(),
+                // perp is in-memory only; reconstructed empty from the bincode mirror.
+                perp: None,
             }
         }
     }
@@ -587,6 +598,7 @@ mod tests {
             receipts: receipts.clone(),
             requests: requests.clone(),
             first_block,
+            perp: None,
         };
 
         // Assert that creating a new ExecutionOutcome using the constructor matches exec_res
@@ -643,6 +655,7 @@ mod tests {
             receipts,
             requests: vec![],
             first_block,
+            perp: None,
         };
 
         // Test before the first block
@@ -675,6 +688,7 @@ mod tests {
             receipts,
             requests: vec![],
             first_block,
+            perp: None,
         };
 
         // Get logs for block number 123
@@ -704,6 +718,7 @@ mod tests {
             receipts,                   // Include the created receipts
             requests: vec![],           // Empty vector for requests
             first_block,                // Set the first block number
+            perp: None,
         };
 
         // Get receipts for block number 123 and convert the result into a vector
@@ -744,6 +759,7 @@ mod tests {
             receipts,                   // Include the created receipts
             requests: vec![],           // Empty vector for requests
             first_block,                // Set the first block number
+            perp: None,
         };
 
         // Assert that the length of receipts in exec_res is 1
@@ -758,6 +774,7 @@ mod tests {
             receipts: receipts_empty,   // Include the empty receipts
             requests: vec![],           // Empty vector for requests
             first_block,                // Set the first block number
+            perp: None,
         };
 
         // Assert that the length of receipts in exec_res_empty_receipts is 0
@@ -793,7 +810,7 @@ mod tests {
         // Create a ExecutionOutcome object with the created bundle, receipts, requests, and
         // first_block
         let mut exec_res =
-            ExecutionOutcome { bundle: Default::default(), receipts, requests, first_block };
+            ExecutionOutcome { bundle: Default::default(), receipts, requests, first_block, perp: None };
 
         // Assert that the revert_to method returns true when reverting to the initial block number.
         assert!(exec_res.revert_to(123));
@@ -837,7 +854,7 @@ mod tests {
 
         // Create an ExecutionOutcome object.
         let mut exec_res =
-            ExecutionOutcome { bundle: Default::default(), receipts, requests, first_block };
+            ExecutionOutcome { bundle: Default::default(), receipts, requests, first_block, perp: None };
 
         // Extend the ExecutionOutcome object by itself.
         exec_res.extend(exec_res.clone());
@@ -850,6 +867,7 @@ mod tests {
                 receipts: vec![vec![Some(receipt.clone())], vec![Some(receipt)]],
                 requests: vec![Requests::new(vec![request.clone()]), Requests::new(vec![request])],
                 first_block: 123,
+                perp: None,
             }
         );
     }
@@ -887,7 +905,7 @@ mod tests {
         // Create a ExecutionOutcome object with the created bundle, receipts, requests, and
         // first_block
         let exec_res =
-            ExecutionOutcome { bundle: Default::default(), receipts, requests, first_block };
+            ExecutionOutcome { bundle: Default::default(), receipts, requests, first_block, perp: None };
 
         // Split the ExecutionOutcome at block number 124
         let result = exec_res.clone().split_at(124);
@@ -898,6 +916,7 @@ mod tests {
             receipts: vec![vec![Some(receipt.clone())]],
             requests: vec![Requests::new(vec![request.clone()])],
             first_block,
+            perp: None,
         };
 
         // Define the expected higher ExecutionOutcome after splitting
@@ -906,6 +925,7 @@ mod tests {
             receipts: vec![vec![Some(receipt.clone())], vec![Some(receipt)]],
             requests: vec![Requests::new(vec![request.clone()]), Requests::new(vec![request])],
             first_block: 124,
+            perp: None,
         };
 
         // Assert that the split result matches the expected lower and higher outcomes
@@ -966,6 +986,7 @@ mod tests {
             receipts: Default::default(),
             first_block: 0,
             requests: vec![],
+            perp: None,
         };
 
         // Get the changed accounts

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -24,6 +24,10 @@ alloy-primitives.workspace = true
 # revm
 revm.workspace = true
 
+# misc
+# Only needed by `PerpDb` (off-trie PerpState cold-read), which is std-gated.
+parking_lot = { workspace = true, optional = true }
+
 [dev-dependencies]
 reth-trie.workspace = true
 reth-ethereum-forks.workspace = true
@@ -39,6 +43,7 @@ std = [
     "reth-ethereum-forks/std",
     "reth-storage-api/std",
     "reth-storage-errors/std",
+    "dep:parking_lot",
 ]
 witness = ["dep:reth-trie"]
 test-utils = [

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -24,10 +24,6 @@ alloy-primitives.workspace = true
 # revm
 revm.workspace = true
 
-# misc
-# Only needed by `PerpDb` (off-trie PerpState cold-read), which is std-gated.
-parking_lot = { workspace = true, optional = true }
-
 [dev-dependencies]
 reth-trie.workspace = true
 reth-ethereum-forks.workspace = true
@@ -43,7 +39,6 @@ std = [
     "reth-ethereum-forks/std",
     "reth-storage-api/std",
     "reth-storage-errors/std",
-    "dep:parking_lot",
 ]
 witness = ["dep:reth-trie"]
 test-utils = [

--- a/crates/revm/src/database.rs
+++ b/crates/revm/src/database.rs
@@ -169,3 +169,102 @@ impl<DB: EvmStateProvider> DatabaseRef for StateProviderDatabase<DB> {
         Ok(self.0.block_hash(number)?.unwrap_or_default())
     }
 }
+
+/// Cloneable read handle to the off-trie PerpDEX canonical store ("PerpState").
+///
+/// The same `Arc` is shared with `reth_chain_state::CanonicalInMemoryState::canonical_perp`; it
+/// maps a domain key to its committed orderbook blob (empty/absent => no committed value).
+#[cfg(feature = "std")]
+pub type PerpHandle =
+    std::sync::Arc<parking_lot::RwLock<alloy_primitives::map::HashMap<B256, alloc::vec::Vec<u8>>>>;
+
+/// Wraps a [`Database`]/[`DatabaseRef`] so off-trie PerpDEX cold reads resolve to the committed
+/// `canonical_perp` store, while all trie-backed reads forward unchanged to the inner database.
+///
+/// This is the read counterpart of revm's journal perp section: when the EVM's `perp_load` misses
+/// the in-block overlay, revm calls [`Database::perp_storage`], which resolves here to the
+/// committed off-trie store instead of returning empty. The perp store is intentionally NOT in the
+/// state trie, so it is served from this side channel rather than via [`Database::storage`].
+#[cfg(feature = "std")]
+#[derive(Clone)]
+pub struct PerpDb<DB> {
+    inner: DB,
+    perp: PerpHandle,
+}
+
+#[cfg(feature = "std")]
+impl<DB> PerpDb<DB> {
+    /// Wraps `inner`, serving perp cold reads from the shared `canonical_perp` handle.
+    pub const fn new(inner: DB, perp: PerpHandle) -> Self {
+        Self { inner, perp }
+    }
+
+    /// Consumes the wrapper, returning the inner database.
+    pub fn into_inner(self) -> DB {
+        self.inner
+    }
+
+    #[inline]
+    fn perp_get(&self, key: B256) -> alloc::vec::Vec<u8> {
+        self.perp.read().get(&key).cloned().unwrap_or_default()
+    }
+}
+
+#[cfg(feature = "std")]
+impl<DB> core::fmt::Debug for PerpDb<DB> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PerpDb").finish_non_exhaustive()
+    }
+}
+
+#[cfg(feature = "std")]
+impl<DB: Database> Database for PerpDb<DB> {
+    type Error = DB::Error;
+
+    fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        self.inner.basic(address)
+    }
+
+    fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        self.inner.code_by_hash(code_hash)
+    }
+
+    fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
+        self.inner.storage(address, index)
+    }
+
+    fn block_hash(&mut self, number: u64) -> Result<B256, Self::Error> {
+        self.inner.block_hash(number)
+    }
+
+    /// Off-trie PerpDEX cold read: resolves from the committed `canonical_perp` store.
+    fn perp_storage(&mut self, key: B256) -> Result<alloc::vec::Vec<u8>, Self::Error> {
+        Ok(self.perp_get(key))
+    }
+}
+
+#[cfg(feature = "std")]
+impl<DB: DatabaseRef> DatabaseRef for PerpDb<DB> {
+    type Error = DB::Error;
+
+    fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        self.inner.basic_ref(address)
+    }
+
+    fn code_by_hash_ref(&self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        self.inner.code_by_hash_ref(code_hash)
+    }
+
+    fn storage_ref(&self, address: Address, index: U256) -> Result<U256, Self::Error> {
+        self.inner.storage_ref(address, index)
+    }
+
+    fn block_hash_ref(&self, number: u64) -> Result<B256, Self::Error> {
+        self.inner.block_hash_ref(number)
+    }
+
+    /// Off-trie PerpDEX cold read: resolves from the committed `canonical_perp` store.
+    fn perp_storage_ref(&self, key: B256) -> Result<alloc::vec::Vec<u8>, Self::Error> {
+        Ok(self.perp_get(key))
+    }
+}

--- a/crates/revm/src/database.rs
+++ b/crates/revm/src/database.rs
@@ -170,13 +170,13 @@ impl<DB: EvmStateProvider> DatabaseRef for StateProviderDatabase<DB> {
     }
 }
 
-/// Cloneable read handle to the off-trie PerpDEX canonical store ("PerpState").
+/// Off-trie PerpState read-handle type, defined in `reth-storage-api`.
 ///
-/// The same `Arc` is shared with `reth_chain_state::CanonicalInMemoryState::canonical_perp`; it
-/// maps a domain key to its committed orderbook blob (empty/absent => no committed value).
+/// Re-exported here so existing `reth_revm::database::PerpHandle` imports keep working; it now
+/// means `Arc<dyn PerpStateHandle>` — a trait object that resolves a domain key to its committed
+/// orderbook blob (empty => no committed value).
 #[cfg(feature = "std")]
-pub type PerpHandle =
-    std::sync::Arc<parking_lot::RwLock<alloy_primitives::map::HashMap<B256, alloc::vec::Vec<u8>>>>;
+pub use reth_storage_api::{PerpHandle, PerpStateHandle};
 
 /// Wraps a [`Database`]/[`DatabaseRef`] so off-trie PerpDEX cold reads resolve to the committed
 /// `canonical_perp` store, while all trie-backed reads forward unchanged to the inner database.
@@ -189,13 +189,14 @@ pub type PerpHandle =
 #[derive(Clone)]
 pub struct PerpDb<DB> {
     inner: DB,
-    perp: PerpHandle,
+    perp: Option<PerpHandle>,
 }
 
 #[cfg(feature = "std")]
 impl<DB> PerpDb<DB> {
-    /// Wraps `inner`, serving perp cold reads from the shared `canonical_perp` handle.
-    pub const fn new(inner: DB, perp: PerpHandle) -> Self {
+    /// Wraps `inner`; when `perp` is `Some`, serves perp cold reads from the shared
+    /// `canonical_perp` handle; when `None`, always returns empty.
+    pub const fn new(inner: DB, perp: Option<PerpHandle>) -> Self {
         Self { inner, perp }
     }
 
@@ -206,7 +207,10 @@ impl<DB> PerpDb<DB> {
 
     #[inline]
     fn perp_get(&self, key: B256) -> alloc::vec::Vec<u8> {
-        self.perp.read().get(&key).cloned().unwrap_or_default()
+        match &self.perp {
+            Some(h) => h.perp_get(key),
+            None => alloc::vec::Vec::new(),
+        }
     }
 }
 
@@ -266,5 +270,56 @@ impl<DB: DatabaseRef> DatabaseRef for PerpDb<DB> {
     /// Off-trie PerpDEX cold read: resolves from the committed `canonical_perp` store.
     fn perp_storage_ref(&self, key: B256) -> Result<alloc::vec::Vec<u8>, Self::Error> {
         Ok(self.perp_get(key))
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod perp_db_tests {
+    use super::*;
+    use alloc::{sync::Arc, vec, vec::Vec};
+    use reth_storage_api::PerpStateHandle;
+
+    struct OneKey(B256, Vec<u8>);
+    impl PerpStateHandle for OneKey {
+        fn perp_get(&self, key: B256) -> Vec<u8> {
+            if key == self.0 {
+                self.1.clone()
+            } else {
+                Vec::new()
+            }
+        }
+    }
+
+    #[derive(Default)]
+    struct NoopInner;
+    impl DatabaseRef for NoopInner {
+        type Error = core::convert::Infallible;
+        fn basic_ref(&self, _: Address) -> Result<Option<AccountInfo>, Self::Error> {
+            Ok(None)
+        }
+        fn code_by_hash_ref(&self, _: B256) -> Result<Bytecode, Self::Error> {
+            Ok(Bytecode::default())
+        }
+        fn storage_ref(&self, _: Address, _: U256) -> Result<U256, Self::Error> {
+            Ok(U256::ZERO)
+        }
+        fn block_hash_ref(&self, _: u64) -> Result<B256, Self::Error> {
+            Ok(B256::ZERO)
+        }
+    }
+
+    #[test]
+    fn none_handle_returns_empty() {
+        let db = PerpDb::new(NoopInner, None);
+        assert!(db.perp_storage_ref(B256::with_last_byte(1)).unwrap().is_empty());
+    }
+
+    #[test]
+    fn some_handle_returns_committed() {
+        let key = B256::with_last_byte(1);
+        let handle: PerpHandle = Arc::new(OneKey(key, vec![4u8, 2]));
+        let db = PerpDb::new(NoopInner, Some(handle));
+        assert_eq!(db.perp_storage_ref(key).unwrap(), vec![4u8, 2]);
+        assert!(db.perp_storage_ref(B256::with_last_byte(2)).unwrap().is_empty());
     }
 }

--- a/crates/revm/src/database.rs
+++ b/crates/revm/src/database.rs
@@ -205,6 +205,11 @@ impl<DB> PerpDb<DB> {
         self.inner
     }
 
+    /// Returns a shared reference to the inner (trie-backed) database.
+    pub const fn inner(&self) -> &DB {
+        &self.inner
+    }
+
     #[inline]
     fn perp_get(&self, key: B256) -> alloc::vec::Vec<u8> {
         match &self.perp {

--- a/crates/rpc/rpc-eth-api/Cargo.toml
+++ b/crates/rpc/rpc-eth-api/Cargo.toml
@@ -20,7 +20,8 @@ reth-primitives-traits = { workspace = true, features = ["rpc-compat"] }
 reth-errors.workspace = true
 reth-evm.workspace = true
 reth-storage-api.workspace = true
-reth-revm.workspace = true
+# std 启用 `PerpDb`(off-trie PerpState 冷读 wrapper)。
+reth-revm = { workspace = true, features = ["std"] }
 reth-rpc-convert.workspace = true
 reth-tasks = { workspace = true, features = ["rayon"] }
 reth-transaction-pool.workspace = true

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -26,7 +26,7 @@ use reth_evm::{
 use reth_node_api::BlockBody;
 use reth_primitives_traits::Recovered;
 use reth_revm::{
-    database::StateProviderDatabase,
+    database::{PerpDb, StateProviderDatabase},
     db::{CacheDB, State},
 };
 use reth_rpc_convert::{RpcConvert, RpcTxReq};
@@ -95,9 +95,11 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
             let mut parent = base_block.sealed_header().clone();
 
             let this = self.clone();
+            let perp = self.perp_handle();
             self.spawn_with_state_at_block(block, move |state| {
-                let mut db =
-                    State::builder().with_database(StateProviderDatabase::new(state)).build();
+                let mut db = State::builder()
+                    .with_database(PerpDb::new(StateProviderDatabase::new(state), perp.clone()))
+                    .build();
                 let mut blocks: Vec<SimulatedBlock<RpcBlock<Self::NetworkTypes>>> =
                     Vec::with_capacity(block_state_calls.len());
                 for block in block_state_calls {
@@ -280,9 +282,10 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
             }
 
             let this = self.clone();
+            let perp = self.perp_handle();
             self.spawn_with_state_at_block(at.into(), move |state| {
                 let mut all_results = Vec::with_capacity(bundles.len());
-                let mut db = CacheDB::new(StateProviderDatabase::new(state));
+                let mut db = CacheDB::new(PerpDb::new(StateProviderDatabase::new(state), perp.clone()));
 
                 if replay_block_txs {
                     // only need to replay the transactions in the block if not all transactions are
@@ -378,9 +381,10 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
     where
         Self: Trace,
     {
+        let perp = self.perp_handle();
         self.spawn_blocking_io_fut(move |this| async move {
             let state = this.state_at_block_id(at).await?;
-            let mut db = CacheDB::new(StateProviderDatabase::new(state));
+            let mut db = CacheDB::new(PerpDb::new(StateProviderDatabase::new(state), perp.clone()));
 
             if let Some(state_overrides) = state_override {
                 apply_state_overrides(state_overrides, &mut db)
@@ -608,10 +612,13 @@ pub trait Call:
         async move {
             let (evm_env, at) = self.evm_env_at(at).await?;
             let this = self.clone();
+            let perp = self.perp_handle();
             self.spawn_blocking_io_fut(move |_| async move {
                 let state = this.state_at_block_id(at).await?;
-                let mut db =
-                    CacheDB::new(StateProviderDatabase::new(StateProviderTraitObjWrapper(&state)));
+                let mut db = CacheDB::new(PerpDb::new(
+                    StateProviderDatabase::new(StateProviderTraitObjWrapper(&state)),
+                    perp.clone(),
+                ));
 
                 let (evm_env, tx_env) =
                     this.prepare_call_env(evm_env, request, &mut db, overrides)?;
@@ -661,8 +668,9 @@ pub trait Call:
             let parent_block = block.parent_hash();
 
             let this = self.clone();
+            let perp = self.perp_handle();
             self.spawn_with_state_at_block(parent_block.into(), move |state| {
-                let mut db = CacheDB::new(StateProviderDatabase::new(state));
+                let mut db = CacheDB::new(PerpDb::new(StateProviderDatabase::new(state), perp.clone()));
                 let block_txs = block.transactions_recovered();
 
                 // replay all transactions prior to the targeted transaction

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -10,7 +10,10 @@ use futures::Future;
 use reth_chainspec::MIN_TRANSACTION_GAS;
 use reth_errors::ProviderError;
 use reth_evm::{ConfigureEvm, Database, Evm, EvmEnvFor, EvmFor, TransactionEnv, TxEnvFor};
-use reth_revm::{database::StateProviderDatabase, db::CacheDB};
+use reth_revm::{
+    database::{PerpDb, StateProviderDatabase},
+    db::CacheDB,
+};
 use reth_rpc_convert::{RpcConvert, RpcTxReq};
 use reth_rpc_eth_types::{
     error::{api::FromEvmHalt, FromEvmError},
@@ -78,7 +81,7 @@ pub trait EstimateCall: Call {
             .unwrap_or(max_gas_limit);
 
         // Configure the evm env
-        let mut db = CacheDB::new(StateProviderDatabase::new(state));
+        let mut db = CacheDB::new(PerpDb::new(StateProviderDatabase::new(state), self.perp_handle()));
 
         // Apply any state overrides if specified.
         if let Some(state_override) = state_override {
@@ -91,7 +94,7 @@ pub trait EstimateCall: Call {
         let mut is_basic_transfer = false;
         if tx_env.input().is_empty() {
             if let TxKind::Call(to) = tx_env.kind() {
-                if let Ok(code) = db.db.account_code(&to) {
+                if let Ok(code) = db.db.inner().account_code(&to) {
                     is_basic_transfer = code.map(|code| code.is_empty()).unwrap_or(true);
                 }
             }

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -204,6 +204,14 @@ pub trait LoadState:
         RpcConvert: RpcConvert<Network = Self::NetworkTypes>,
     > + RpcNodeCoreExt
 {
+    /// call/trace 执行期 off-trie `PerpState` 冷读句柄。
+    ///
+    /// 经底层 provider 的 [`StateProviderFactory::canonical_perp`] 解析;
+    /// 无 canonical perp 存储的 provider 返回 `None`。
+    fn perp_handle(&self) -> Option<reth_storage_api::PerpHandle> {
+        self.provider().canonical_perp()
+    }
+
     /// Returns the state at the given block number
     fn state_at_hash(&self, block_hash: B256) -> Result<StateProviderBox, Self::Error> {
         self.provider().history_by_block_hash(block_hash).map_err(Self::Error::from_eth_err)

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -13,7 +13,10 @@ use reth_evm::{
     Evm, EvmEnvFor, EvmFor, HaltReasonFor, InspectorFor, TxEnvFor,
 };
 use reth_primitives_traits::{BlockBody, Recovered, RecoveredBlock};
-use reth_revm::{database::StateProviderDatabase, db::CacheDB};
+use reth_revm::{
+    database::{PerpDb, StateProviderDatabase},
+    db::CacheDB,
+};
 use reth_rpc_eth_types::{
     cache::db::{StateCacheDb, StateCacheDbRefMutWrapper, StateProviderTraitObjWrapper},
     EthApiError,
@@ -67,8 +70,9 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> {
             + Send
             + 'static,
     {
+        let perp = self.perp_handle();
         self.with_state_at_block(at, move |this, state| {
-            let mut db = CacheDB::new(StateProviderDatabase::new(state));
+            let mut db = CacheDB::new(PerpDb::new(StateProviderDatabase::new(state), perp.clone()));
             let mut inspector = TracingInspector::new(config);
             let res = this.inspect(&mut db, evm_env, tx_env, &mut inspector)?;
             f(inspector, res)
@@ -102,8 +106,9 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> {
         R: Send + 'static,
     {
         let this = self.clone();
+        let perp = self.perp_handle();
         self.spawn_with_state_at_block(at, move |state| {
-            let mut db = CacheDB::new(StateProviderDatabase::new(state));
+            let mut db = CacheDB::new(PerpDb::new(StateProviderDatabase::new(state), perp.clone()));
             let mut inspector = TracingInspector::new(config);
             let res = this.inspect(&mut db, evm_env, tx_env, &mut inspector)?;
             f(inspector, res, db)
@@ -183,8 +188,9 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> {
             let parent_block = block.parent_hash();
 
             let this = self.clone();
+            let perp = self.perp_handle();
             self.spawn_with_state_at_block(parent_block.into(), move |state| {
-                let mut db = CacheDB::new(StateProviderDatabase::new(state));
+                let mut db = CacheDB::new(PerpDb::new(StateProviderDatabase::new(state), perp.clone()));
                 let block_txs = block.transactions_recovered();
 
                 this.apply_pre_execution_changes(&block, &mut db, &evm_env)?;
@@ -295,6 +301,7 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> {
             }
 
             // replay all transactions of the block
+            let perp = self.perp_handle();
             self.spawn_blocking_io_fut(move |this| async move {
                 // we need to get the state of the parent block because we're replaying this block
                 // on top of its parent block's state
@@ -306,8 +313,10 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> {
 
                 // now get the state
                 let state = this.state_at_block_id(state_at.into()).await?;
-                let mut db =
-                    CacheDB::new(StateProviderDatabase::new(StateProviderTraitObjWrapper(&state)));
+                let mut db = CacheDB::new(PerpDb::new(
+                    StateProviderDatabase::new(StateProviderTraitObjWrapper(&state)),
+                    perp.clone(),
+                ));
 
                 this.apply_pre_execution_changes(&block, &mut db, &evm_env)?;
 

--- a/crates/rpc/rpc-eth-types/Cargo.toml
+++ b/crates/rpc/rpc-eth-types/Cargo.toml
@@ -21,7 +21,8 @@ reth-metrics.workspace = true
 reth-ethereum-primitives = { workspace = true, features = ["rpc"] }
 reth-primitives-traits = { workspace = true, features = ["rpc-compat"] }
 reth-storage-api.workspace = true
-reth-revm.workspace = true
+# std 启用 `PerpDb`(StateCacheDb 别名经其包裹 off-trie PerpState 冷读)。
+reth-revm = { workspace = true, features = ["std"] }
 reth-rpc-server-types.workspace = true
 reth-rpc-convert.workspace = true
 reth-tasks.workspace = true

--- a/crates/rpc/rpc-eth-types/src/cache/db.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/db.rs
@@ -214,6 +214,13 @@ impl<'a> Database for StateCacheDbRefMutWrapper<'a, '_> {
     fn block_hash(&mut self, number: u64) -> Result<B256, Self::Error> {
         self.0.block_hash(number)
     }
+
+    /// Forward off-trie `PerpState` cold reads to the inner [`PerpDb`]. Without this, the EVM
+    /// would see an empty orderbook through this wrapper on the `eth_call` / `spawn_with_call_at`
+    /// execution path, since the `Database::perp_storage` default returns an empty `Vec`.
+    fn perp_storage(&mut self, key: B256) -> Result<Vec<u8>, Self::Error> {
+        self.0.perp_storage(key)
+    }
 }
 
 impl<'a> DatabaseRef for StateCacheDbRefMutWrapper<'a, '_> {
@@ -233,6 +240,11 @@ impl<'a> DatabaseRef for StateCacheDbRefMutWrapper<'a, '_> {
 
     fn block_hash_ref(&self, number: u64) -> Result<B256, Self::Error> {
         self.0.block_hash_ref(number)
+    }
+
+    /// Forward off-trie `PerpState` cold reads to the inner [`PerpDb`] (see [`Database::perp_storage`]).
+    fn perp_storage_ref(&self, key: B256) -> Result<Vec<u8>, Self::Error> {
+        self.0.perp_storage_ref(key)
     }
 }
 

--- a/crates/rpc/rpc-eth-types/src/cache/db.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/db.rs
@@ -4,7 +4,10 @@
 
 use alloy_primitives::{Address, B256, U256};
 use reth_errors::ProviderResult;
-use reth_revm::{database::StateProviderDatabase, DatabaseRef};
+use reth_revm::{
+    database::{PerpDb, StateProviderDatabase},
+    DatabaseRef,
+};
 use reth_storage_api::{BytecodeReader, HashedPostStateProvider, StateProvider};
 use reth_trie::{HashedStorage, MultiProofTargets};
 use revm::{
@@ -14,8 +17,12 @@ use revm::{
     Database, DatabaseCommit,
 };
 
-/// Helper alias type for the state's [`CacheDB`]
-pub type StateCacheDb<'a> = CacheDB<StateProviderDatabase<StateProviderTraitObjWrapper<'a>>>;
+/// Helper alias type for the state's [`CacheDB`].
+///
+/// Wraps the trie-backed db in [`PerpDb`] so off-trie `PerpState` cold reads resolve to the
+/// committed `canonical_perp` store on the RPC call/trace execution paths.
+pub type StateCacheDb<'a> =
+    CacheDB<PerpDb<StateProviderDatabase<StateProviderTraitObjWrapper<'a>>>>;
 
 /// Hack to get around 'higher-ranked lifetime error', see
 /// <https://github.com/rust-lang/rust/issues/100013>

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -26,7 +26,7 @@ reth-chain-state.workspace = true
 reth-transaction-pool.workspace = true
 reth-network-api.workspace = true
 reth-rpc-engine-api.workspace = true
-reth-revm = { workspace = true, features = ["witness"] }
+reth-revm = { workspace = true, features = ["witness", "std"] }
 reth-tasks = { workspace = true, features = ["rayon"] }
 reth-rpc-convert.workspace = true
 revm-inspectors.workspace = true

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -21,7 +21,7 @@ use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_evm::{execute::Executor, ConfigureEvm, EvmEnvFor, TxEnvFor};
 use reth_primitives_traits::{Block as _, BlockBody, ReceiptWithBloom, RecoveredBlock};
 use reth_revm::{
-    database::StateProviderDatabase,
+    database::{PerpDb, StateProviderDatabase},
     db::{CacheDB, State},
     witness::ExecutionWitnessRecord,
 };
@@ -95,10 +95,12 @@ where
     ) -> Result<Vec<TraceResult>, Eth::Error> {
         // replay all transactions of the block
         let this = self.clone();
+        let perp = self.eth_api().perp_handle();
         self.eth_api()
             .spawn_with_state_at_block(block.parent_hash().into(), move |state| {
                 let mut results = Vec::with_capacity(block.body().transactions().len());
-                let mut db = CacheDB::new(StateProviderDatabase::new(state));
+                let mut db =
+                    CacheDB::new(PerpDb::new(StateProviderDatabase::new(state), perp.clone()));
 
                 this.eth_api().apply_pre_execution_changes(&block, &mut db, &evm_env)?;
 
@@ -220,6 +222,7 @@ where
         let block_hash = block.hash();
 
         let this = self.clone();
+        let perp = self.eth_api().perp_handle();
         self.eth_api()
             .spawn_with_state_at_block(state_at, move |state| {
                 let block_txs = block.transactions_recovered();
@@ -227,7 +230,8 @@ where
                 // configure env for the target transaction
                 let tx = transaction.into_recovered();
 
-                let mut db = CacheDB::new(StateProviderDatabase::new(state));
+                let mut db =
+                    CacheDB::new(PerpDb::new(StateProviderDatabase::new(state), perp.clone()));
 
                 this.eth_api().apply_pre_execution_changes(&block, &mut db, &evm_env)?;
 
@@ -522,12 +526,14 @@ where
         }
 
         let this = self.clone();
+        let perp = self.eth_api().perp_handle();
 
         self.eth_api()
             .spawn_with_state_at_block(at.into(), move |state| {
                 // the outer vec for the bundles
                 let mut all_bundles = Vec::with_capacity(bundles.len());
-                let mut db = CacheDB::new(StateProviderDatabase::new(state));
+                let mut db =
+                    CacheDB::new(PerpDb::new(StateProviderDatabase::new(state), perp.clone()));
 
                 if replay_block_txs {
                     // only need to replay the transactions in the block if not all transactions are
@@ -634,11 +640,12 @@ where
     ) -> Result<ExecutionWitness, Eth::Error> {
         let this = self.clone();
         let block_number = block.header().number();
+        let perp = self.eth_api().perp_handle();
 
         let (mut exec_witness, lowest_block_number) = self
             .eth_api()
             .spawn_with_state_at_block(block.parent_hash().into(), move |state_provider| {
-                let db = StateProviderDatabase::new(&state_provider);
+                let db = PerpDb::new(StateProviderDatabase::new(&state_provider), perp.clone());
                 let block_executor = this.eth_api().evm_config().executor(db);
 
                 let mut witness_record = ExecutionWitnessRecord::default();

--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -20,7 +20,10 @@ use jsonrpsee::core::RpcResult;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardfork, MAINNET, SEPOLIA};
 use reth_evm::ConfigureEvm;
 use reth_primitives_traits::{BlockBody, BlockHeader};
-use reth_revm::{database::StateProviderDatabase, db::CacheDB};
+use reth_revm::{
+    database::{PerpDb, StateProviderDatabase},
+    db::CacheDB,
+};
 use reth_rpc_api::TraceApiServer;
 use reth_rpc_convert::RpcTxReq;
 use reth_rpc_eth_api::{
@@ -154,11 +157,13 @@ where
         let (evm_env, at) = self.eth_api().evm_env_at(at).await?;
 
         let this = self.clone();
+        let perp = self.eth_api().perp_handle();
         // execute all transactions on top of each other and record the traces
         self.eth_api()
             .spawn_with_state_at_block(at, move |state| {
                 let mut results = Vec::with_capacity(calls.len());
-                let mut db = CacheDB::new(StateProviderDatabase::new(state));
+                let mut db =
+                    CacheDB::new(PerpDb::new(StateProviderDatabase::new(state), perp.clone()));
 
                 let mut calls = calls.into_iter().peekable();
 

--- a/crates/storage/db-api/src/tables/mod.rs
+++ b/crates/storage/db-api/src/tables/mod.rs
@@ -523,6 +523,14 @@ tables! {
         type Key = ChainStateKey;
         type Value = BlockNumber;
     }
+
+    /// Off-trie PerpDEX canonical store ("PerpState"): committed orderbook blobs keyed by a
+    /// 32-byte domain key. Written at block persistence (atomically with block state) and read
+    /// at startup to seed the in-memory `canonical_perp`. Off the state trie / state root.
+    table PerpState {
+        type Key = B256;
+        type Value = Vec<u8>;
+    }
 }
 
 /// Keys for the `ChainState` table.

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -609,6 +609,10 @@ impl<N: ProviderNodeTypes> StateProviderFactory for BlockchainProvider<N> {
 
         Ok(None)
     }
+
+    fn canonical_perp(&self) -> Option<reth_storage_api::PerpHandle> {
+        Some(self.canonical_in_memory_state.canonical_perp_handle())
+    }
 }
 
 impl<N: NodeTypesWithDB> HashedPostStateProvider for BlockchainProvider<N> {
@@ -798,6 +802,13 @@ mod tests {
     const TEST_BLOCKS_COUNT: usize = 5;
 
     const TEST_TRANSACTIONS_COUNT: u8 = 4;
+
+    #[test]
+    fn mock_provider_inherits_none_perp_handle() {
+        use reth_storage_api::StateProviderFactory;
+        let provider = crate::test_utils::MockEthProvider::default();
+        assert!(provider.canonical_perp().is_none());
+    }
 
     fn random_blocks(
         rng: &mut impl Rng,

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -2613,4 +2613,42 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn restart_recovers_perp_state_from_db() -> eyre::Result<()> {
+        use alloy_primitives::map::HashMap;
+
+        // Build a factory with a persisted head. This crate's tests obtain a head by inserting
+        // a block range into the DB (mirroring `test_block_reader_find_block_by_hash`) rather
+        // than `reth_db_common::init::init_genesis`, which is not a dependency here.
+        let mut rng = generators::rng();
+        let factory = create_test_provider_factory();
+        let blocks = random_block_range(
+            &mut rng,
+            0..=0,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 0..1, ..Default::default() },
+        );
+
+        // Persist some perp state (as the persistence service would, atomically with a txn) and
+        // a block so `BlockchainProvider::new` finds a head.
+        let k = B256::with_last_byte(7);
+        let mut delta: HashMap<B256, Vec<u8>> = HashMap::default();
+        delta.insert(k, vec![0xDE, 0xAD]);
+        let provider_rw = factory.provider_rw()?;
+        for block in &blocks {
+            provider_rw.insert_historical_block(
+                block.clone().try_recover().expect("failed to seal block with senders"),
+            )?;
+        }
+        provider_rw.write_perp_state_delta(&delta)?;
+        provider_rw.commit()?;
+
+        // "Restart": brand-new BlockchainProvider over the same (persisted) factory. Fresh
+        // in-memory state, reused DB.
+        let bp = BlockchainProvider::new(factory)?;
+        let store = bp.canonical_in_memory_state().canonical_perp();
+        assert_eq!(store.read().get(&k), Some(&vec![0xDEu8, 0xAD]));
+
+        Ok(())
+    }
 }

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -111,14 +111,11 @@ impl<N: ProviderNodeTypes> BlockchainProvider<N> {
             .map(|num| provider.sealed_header(num))
             .transpose()?
             .flatten();
-        Ok(Self {
-            database: storage,
-            canonical_in_memory_state: CanonicalInMemoryState::with_head(
-                latest,
-                finalized_header,
-                safe_header,
-            ),
-        })
+        let canonical_in_memory_state =
+            CanonicalInMemoryState::with_head(latest, finalized_header, safe_header);
+        // Seed the off-trie PerpDEX store from its durable table so perp state survives restart.
+        canonical_in_memory_state.seed_perp(provider.read_all_perp_state()?);
+        Ok(Self { database: storage, canonical_in_memory_state })
     }
 
     /// Gets a clone of `canonical_in_memory_state`.

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -3080,6 +3080,40 @@ impl<TX: DbTxMut, N: NodeTypes> ChainStateBlockWriter for DatabaseProvider<TX, N
     }
 }
 
+impl<TX: DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
+    /// Reads the entire off-trie `PerpState` table into a map (materialized perp state as of
+    /// the persisted head). Used at startup to seed the in-memory `canonical_perp`.
+    pub fn read_all_perp_state(
+        &self,
+    ) -> ProviderResult<alloy_primitives::map::HashMap<B256, Vec<u8>>> {
+        let mut map = alloy_primitives::map::HashMap::default();
+        for entry in self.tx.cursor_read::<tables::PerpState>()?.walk(None)? {
+            let (key, value) = entry?;
+            map.insert(key, value);
+        }
+        Ok(map)
+    }
+}
+
+impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
+    /// Applies one block's net off-trie PerpDEX delta to the durable `PerpState` table:
+    /// empty value = delete the key, otherwise upsert. Runs in the caller's RW transaction so
+    /// it commits atomically with the block state.
+    pub fn write_perp_state_delta(
+        &self,
+        delta: &alloy_primitives::map::HashMap<B256, Vec<u8>>,
+    ) -> ProviderResult<()> {
+        for (key, value) in delta {
+            if value.is_empty() {
+                self.tx.delete::<tables::PerpState>(*key, None)?;
+            } else {
+                self.tx.put::<tables::PerpState>(*key, value.clone())?;
+            }
+        }
+        Ok(())
+    }
+}
+
 impl<TX: DbTx + 'static, N: NodeTypes + 'static> DBProvider for DatabaseProvider<TX, N> {
     type Tx = TX;
 
@@ -3108,6 +3142,39 @@ mod tests {
         BlockWriter,
     };
     use reth_testing_utils::generators::{self, random_block, BlockParams};
+
+    #[test]
+    fn perp_state_round_trips_through_db() {
+        use alloy_primitives::{map::HashMap, B256};
+
+        let factory = create_test_provider_factory();
+
+        // write a delta: insert two keys, then a delete marker (empty value) on a third.
+        let k1 = B256::with_last_byte(1);
+        let k2 = B256::with_last_byte(2);
+        let k3 = B256::with_last_byte(3);
+        let mut delta: HashMap<B256, Vec<u8>> = HashMap::default();
+        delta.insert(k1, vec![0xAA, 0xBB]);
+        delta.insert(k2, vec![0xCC]);
+
+        let provider_rw = factory.provider_rw().unwrap();
+        provider_rw.write_perp_state_delta(&delta).unwrap();
+        provider_rw.commit().unwrap();
+
+        // delete k1 via empty-value delta, in a second commit.
+        let mut del: HashMap<B256, Vec<u8>> = HashMap::default();
+        del.insert(k1, Vec::new());
+        let provider_rw = factory.provider_rw().unwrap();
+        provider_rw.write_perp_state_delta(&del).unwrap();
+        provider_rw.commit().unwrap();
+
+        // read back the materialized state.
+        let got = factory.provider().unwrap().read_all_perp_state().unwrap();
+        assert_eq!(got.get(&k2), Some(&vec![0xCCu8]));
+        assert_eq!(got.get(&k1), None); // deleted
+        assert_eq!(got.get(&k3), None); // never written
+        assert_eq!(got.len(), 1);
+    }
 
     #[test]
     fn test_receipts_by_block_range_empty_range() {

--- a/crates/storage/provider/src/writer/mod.rs
+++ b/crates/storage/provider/src/writer/mod.rs
@@ -1083,6 +1083,7 @@ mod tests {
             receipts: vec![vec![Receipt::default(); 2]; 7],
             first_block: 10,
             requests: Vec::new(),
+            perp: None,
         };
 
         let mut this = base.clone();
@@ -1304,6 +1305,7 @@ mod tests {
             receipts: vec![vec![Receipt::default(); 2]; 1],
             first_block: 2,
             requests: Vec::new(),
+            perp: None,
         };
 
         test.prepend_state(previous_state);

--- a/crates/storage/storage-api/src/lib.rs
+++ b/crates/storage/storage-api/src/lib.rs
@@ -42,6 +42,9 @@ pub use receipts::*;
 mod stage_checkpoint;
 pub use stage_checkpoint::*;
 
+mod perp;
+pub use perp::{PerpHandle, PerpStateHandle};
+
 mod state;
 pub use state::*;
 

--- a/crates/storage/storage-api/src/perp.rs
+++ b/crates/storage/storage-api/src/perp.rs
@@ -1,0 +1,15 @@
+//! Off-trie PerpState 读句柄，供共识 EVM 与 RPC 冷读路径共用。
+
+use alloc::{sync::Arc, vec::Vec};
+use alloy_primitives::B256;
+
+/// 对 off-trie PerpDEX 存储(`canonical_perp`)的只读句柄。
+///
+/// 返回空 `Vec` 表示该 key 不存在。object-safe，可作 `dyn` 使用。
+pub trait PerpStateHandle: Send + Sync {
+    /// 返回 `key` 对应的已提交字节；不存在则返回空 `Vec`。
+    fn perp_get(&self, key: B256) -> Vec<u8>;
+}
+
+/// 可共享、类型擦除的 [`PerpStateHandle`]。
+pub type PerpHandle = Arc<dyn PerpStateHandle>;

--- a/crates/storage/storage-api/src/state.rs
+++ b/crates/storage/storage-api/src/state.rs
@@ -199,4 +199,11 @@ pub trait StateProviderFactory: BlockIdReader + Send + Sync {
     ///
     /// This will return `None` if there's no pending state.
     fn maybe_pending(&self) -> ProviderResult<Option<StateProviderBox>>;
+
+    /// 返回 off-trie PerpDEX 存储的读句柄，仅当该 provider 由 canonical 内存态支撑时为 `Some`。
+    ///
+    /// 默认 `None`(无 perp 存储的 provider，如 RPC/Noop/Mock provider)。
+    fn canonical_perp(&self) -> Option<crate::PerpHandle> {
+        None
+    }
 }


### PR DESCRIPTION
## Summary
Merges the `perpstate-deferred-commit` line into `perpdex` (20 commits, fast-forward — 0 behind):
- **Off-trie `PerpState` persistence**: a dedicated MDBX `PerpState` table; perp delta is persisted atomically with block state on `save_blocks`, and `canonical_perp` is seeded from the table at startup — so a restarted node recovers its in-memory perp state instead of losing it.
- **On-trie chained commitment**: every off-trie perp write folds into `C = keccak256(C‖key‖blob)` stored at a slot under `0x1003` (`keccak256("cmit")`), landing in the state root → **perp-state divergence is consensus-detectable** (a bad recovery halts loudly instead of silently diverging).
- RPC `call/estimate/trace/debug` DBs routed through `PerpDb` for off-trie reads.
- revm pinned at `a7b0699d` (perp commitment-hash commit); alloy-evm unchanged.

## Test Plan / validation (on the 80/20 cluster)
- [x] `cargo check` (db-api, provider, chain-state, engine-tree) + provider tests (`perp_state_round_trips_through_db`, `restart_recovers_perp_state_from_db`, `seed_perp_replaces_whole_map`) pass.
- [x] 2-node serial correctness passes (realisticMix, Preflight mismatch 0, no matching-engine/verifier violations).
- [x] Crash/restart/catch-up: kill the 20% validator, 80% node produces a ~650-block gap, restart (no wipe) → recovers perp state from disk, catches up, commitment slot equal on both nodes — ALL PHASES PASS.
- [x] Negative control: clearing the restarted node's `PerpState` makes it halt at the first perp-write block (state-root mismatch / `INVALID`) and fail to catch up — confirms the commitment has teeth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)