### PR TITLE
feat: upgrade RLPx ECIES handshake to AES-256

### DIFF
--- a/crates/net/ecies/Cargo.toml
+++ b/crates/net/ecies/Cargo.toml
@@ -42,3 +42,6 @@ aes.workspace = true
 hmac.workspace = true
 block-padding.workspace = true
 cipher = { workspace = true, features = ["block-padding"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread"] }

--- a/crates/net/ecies/src/algorithm.rs
+++ b/crates/net/ecies/src/algorithm.rs
@@ -6,7 +6,7 @@ use crate::{
     util::{hmac_sha256, sha256},
     ECIESError,
 };
-use aes::{cipher::StreamCipher, Aes128, Aes256};
+use aes::{cipher::StreamCipher, Aes256};
 use alloy_primitives::{
     bytes::{BufMut, Bytes, BytesMut},
     B128, B256, B512 as PeerId,
@@ -24,7 +24,13 @@ use secp256k1::{
 use sha2::Sha256;
 use sha3::Keccak256;
 
-const PROTOCOL_VERSION: usize = 4;
+/// RLPx handshake protocol version. Version 5 enables AES-256-CTR for ECIES handshake
+/// encryption (0G extension; standard devp2p uses version 4 with AES-128-CTR).
+const PROTOCOL_VERSION: usize = 5;
+
+/// KDF output length for ECIES handshake key derivation: 32-byte encryption key + 16-byte MAC
+/// material.
+const ECIES_KDF_LEN: usize = 48;
 
 /// Computes the shared secret with ECDH and strips the y coordinate after computing the shared
 /// secret.
@@ -48,6 +54,15 @@ fn ecdh_x(public_key: &PublicKey, secret_key: &SecretKey) -> B256 {
 ///   cannot have a len greater than 32 * 2^32 - 1.
 fn kdf(secret: B256, s1: &[u8], dest: &mut [u8]) {
     concat_kdf::derive_key_into::<Sha256>(secret.as_slice(), s1, dest).unwrap();
+}
+
+/// Derives AES-256 encryption and MAC keys for the ECIES handshake from a shared ECDH secret.
+fn derive_ecies_symmetric_keys(shared_secret: B256) -> RLPxSymmetricKeys {
+    let mut key = [0u8; ECIES_KDF_LEN];
+    kdf(shared_secret, &[], &mut key);
+    let enc_key = B256::from_slice(&key[..32]);
+    let mac_key = sha256(&key[32..48]);
+    RLPxSymmetricKeys { enc_key, mac_key }
 }
 
 pub struct ECIES {
@@ -112,7 +127,9 @@ fn split_at_mut<T>(arr: &mut [T], idx: usize) -> Result<(&mut [T], &mut [T]), EC
 /// `(Px, Py) = kB * R` as well as the encryption and authentication keys `kE || kM = KDF(S, 32)`.
 ///
 /// Bob verifies the authenticity of the message by checking whether `d == MAC(sha256(kM), iv ||
-/// c)` then obtains the plaintext as `m = AES(kE, iv || c)`.
+/// c)` then obtains the plaintext as `m = AES-256-CTR(kE, iv || c)`.
+///
+/// 0G extends standard devp2p ECIES (AES-128) by deriving a 32-byte `kE` via `KDF(S, 48)`.
 #[derive(Debug)]
 pub struct EncryptedMessage<'a> {
     /// The auth data, used when checking the `tag` with HMAC-SHA256.
@@ -177,32 +194,10 @@ impl<'a> EncryptedMessage<'a> {
     /// Use the given secret and this encrypted message to derive the shared secret, and use the
     /// shared secret to derive the mac and encryption keys.
     pub fn derive_keys(&self, secret_key: &SecretKey) -> RLPxSymmetricKeys {
-        // perform ECDH to get the shared secret, using the remote public key from the message and
-        // the given secret key
+        // Perform ECDH to get the shared secret, using the remote public key from the message and
+        // the given secret key.
         let x = ecdh_x(&self.public_key, secret_key);
-        let mut key = [0u8; 32];
-
-        // The RLPx spec describes the key derivation process as:
-        //
-        // kE || kM = KDF(S, 32)
-        //
-        // where kE is the encryption key, and kM is used to determine the MAC key (see below)
-        //
-        // NOTE: The RLPx spec does not define an `OtherInfo` parameter, and this is unused in
-        // other implementations, so we use an empty slice.
-        kdf(x, &[], &mut key);
-
-        let enc_key = B128::from_slice(&key[..16]);
-
-        // The MAC tag check operation described is:
-        //
-        // d == MAC(sha256(kM), iv || c)
-        //
-        // where kM is the result of the above KDF, iv is the IV, and c is the encrypted data.
-        // Because the hash of kM is ultimately used as the mac key, we perform that hashing here.
-        let mac_key = sha256(&key[16..32]);
-
-        RLPxSymmetricKeys { enc_key, mac_key }
+        derive_ecies_symmetric_keys(x)
     }
 
     /// Use the given ECIES keys to check the message integrity using the contained tag.
@@ -248,7 +243,7 @@ impl<'a> EncryptedMessage<'a> {
         // rename for clarity once it's decrypted
         let decrypted_data = encrypted_data;
 
-        let mut decryptor = Ctr64BE::<Aes128>::new((&keys.enc_key.0).into(), (&*iv).into());
+        let mut decryptor = Ctr64BE::<Aes256>::new((&keys.enc_key.0).into(), (&*iv).into());
         decryptor.apply_keystream(decrypted_data);
         decrypted_data
     }
@@ -264,9 +259,8 @@ impl<'a> EncryptedMessage<'a> {
 /// The symmetric keys derived from an ECIES message.
 #[derive(Debug)]
 pub struct RLPxSymmetricKeys {
-    /// The key used for decryption, specifically with AES-128 in CTR mode, using a 64-bit big
-    /// endian counter.
-    pub enc_key: B128,
+    /// The key used for decryption with AES-256 in CTR mode, using a 64-bit big-endian counter.
+    pub enc_key: B256,
 
     /// The key used for verifying message integrity, specifically with the NIST SP 800-56A Concat
     /// KDF.
@@ -377,14 +371,10 @@ impl ECIES {
         );
 
         let x = ecdh_x(&self.remote_public_key.unwrap(), &secret_key);
-        let mut key = [0u8; 32];
-        kdf(x, &[], &mut key);
-
-        let enc_key = B128::from_slice(&key[..16]);
-        let mac_key = sha256(&key[16..32]);
+        let RLPxSymmetricKeys { enc_key, mac_key } = derive_ecies_symmetric_keys(x);
 
         let iv = B128::random();
-        let mut encryptor = Ctr64BE::<Aes128>::new((&enc_key.0).into(), (&iv.0).into());
+        let mut encryptor = Ctr64BE::<Aes256>::new((&enc_key.0).into(), (&iv.0).into());
 
         let mut encrypted = data.to_vec();
         encryptor.apply_keystream(&mut encrypted);
@@ -873,93 +863,16 @@ mod tests {
     }
 
     #[test]
-    /// Test vectors from <https://eips.ethereum.org/EIPS/eip-8>
-    fn eip8_test() {
-        // EIP-8 format with version 4 and no additional list elements
-        let auth2 = hex!(
-            "
-        01b304ab7578555167be8154d5cc456f567d5ba302662433674222360f08d5f1534499d3678b513b
-        0fca474f3a514b18e75683032eb63fccb16c156dc6eb2c0b1593f0d84ac74f6e475f1b8d56116b84
-        9634a8c458705bf83a626ea0384d4d7341aae591fae42ce6bd5c850bfe0b999a694a49bbbaf3ef6c
-        da61110601d3b4c02ab6c30437257a6e0117792631a4b47c1d52fc0f8f89caadeb7d02770bf999cc
-        147d2df3b62e1ffb2c9d8c125a3984865356266bca11ce7d3a688663a51d82defaa8aad69da39ab6
-        d5470e81ec5f2a7a47fb865ff7cca21516f9299a07b1bc63ba56c7a1a892112841ca44b6e0034dee
-        70c9adabc15d76a54f443593fafdc3b27af8059703f88928e199cb122362a4b35f62386da7caad09
-        c001edaeb5f8a06d2b26fb6cb93c52a9fca51853b68193916982358fe1e5369e249875bb8d0d0ec3
-        6f917bc5e1eafd5896d46bd61ff23f1a863a8a8dcd54c7b109b771c8e61ec9c8908c733c0263440e
-        2aa067241aaa433f0bb053c7b31a838504b148f570c0ad62837129e547678c5190341e4f1693956c
-        3bf7678318e2d5b5340c9e488eefea198576344afbdf66db5f51204a6961a63ce072c8926c
-        "
-        );
-
-        // EIP-8 format with version 56 and 3 additional list elements (sent from A to B)
-        let auth3 = hex!(
-            "
-        01b8044c6c312173685d1edd268aa95e1d495474c6959bcdd10067ba4c9013df9e40ff45f5bfd6f7
-        2471f93a91b493f8e00abc4b80f682973de715d77ba3a005a242eb859f9a211d93a347fa64b597bf
-        280a6b88e26299cf263b01b8dfdb712278464fd1c25840b995e84d367d743f66c0e54a586725b7bb
-        f12acca27170ae3283c1073adda4b6d79f27656993aefccf16e0d0409fe07db2dc398a1b7e8ee93b
-        cd181485fd332f381d6a050fba4c7641a5112ac1b0b61168d20f01b479e19adf7fdbfa0905f63352
-        bfc7e23cf3357657455119d879c78d3cf8c8c06375f3f7d4861aa02a122467e069acaf513025ff19
-        6641f6d2810ce493f51bee9c966b15c5043505350392b57645385a18c78f14669cc4d960446c1757
-        1b7c5d725021babbcd786957f3d17089c084907bda22c2b2675b4378b114c601d858802a55345a15
-        116bc61da4193996187ed70d16730e9ae6b3bb8787ebcaea1871d850997ddc08b4f4ea668fbf3740
-        7ac044b55be0908ecb94d4ed172ece66fd31bfdadf2b97a8bc690163ee11f5b575a4b44e36e2bfb2
-        f0fce91676fd64c7773bac6a003f481fddd0bae0a1f31aa27504e2a533af4cef3b623f4791b2cca6
-        d490
-        "
-        );
-
-        // EIP-8 format with version 4 and no additional list elements (sent from B to A)
-        let ack2 = hex!(
-            "
-        01ea0451958701280a56482929d3b0757da8f7fbe5286784beead59d95089c217c9b917788989470
-        b0e330cc6e4fb383c0340ed85fab836ec9fb8a49672712aeabbdfd1e837c1ff4cace34311cd7f4de
-        05d59279e3524ab26ef753a0095637ac88f2b499b9914b5f64e143eae548a1066e14cd2f4bd7f814
-        c4652f11b254f8a2d0191e2f5546fae6055694aed14d906df79ad3b407d94692694e259191cde171
-        ad542fc588fa2b7333313d82a9f887332f1dfc36cea03f831cb9a23fea05b33deb999e85489e645f
-        6aab1872475d488d7bd6c7c120caf28dbfc5d6833888155ed69d34dbdc39c1f299be1057810f34fb
-        e754d021bfca14dc989753d61c413d261934e1a9c67ee060a25eefb54e81a4d14baff922180c395d
-        3f998d70f46f6b58306f969627ae364497e73fc27f6d17ae45a413d322cb8814276be6ddd13b885b
-        201b943213656cde498fa0e9ddc8e0b8f8a53824fbd82254f3e2c17e8eaea009c38b4aa0a3f306e8
-        797db43c25d68e86f262e564086f59a2fc60511c42abfb3057c247a8a8fe4fb3ccbadde17514b7ac
-        8000cdb6a912778426260c47f38919a91f25f4b5ffb455d6aaaf150f7e5529c100ce62d6d92826a7
-        1778d809bdf60232ae21ce8a437eca8223f45ac37f6487452ce626f549b3b5fdee26afd2072e4bc7
-        5833c2464c805246155289f4
-        "
-        );
-
-        // EIP-8 format with version 57 and 3 additional list elements (sent from B to A)
-        let ack3 = hex!(
-            "
-        01f004076e58aae772bb101ab1a8e64e01ee96e64857ce82b1113817c6cdd52c09d26f7b90981cd7
-        ae835aeac72e1573b8a0225dd56d157a010846d888dac7464baf53f2ad4e3d584531fa203658fab0
-        3a06c9fd5e35737e417bc28c1cbf5e5dfc666de7090f69c3b29754725f84f75382891c561040ea1d
-        dc0d8f381ed1b9d0d4ad2a0ec021421d847820d6fa0ba66eaf58175f1b235e851c7e2124069fbc20
-        2888ddb3ac4d56bcbd1b9b7eab59e78f2e2d400905050f4a92dec1c4bdf797b3fc9b2f8e84a482f3
-        d800386186712dae00d5c386ec9387a5e9c9a1aca5a573ca91082c7d68421f388e79127a5177d4f8
-        590237364fd348c9611fa39f78dcdceee3f390f07991b7b47e1daa3ebcb6ccc9607811cb17ce51f1
-        c8c2c5098dbdd28fca547b3f58c01a424ac05f869f49c6a34672ea2cbbc558428aa1fe48bbfd6115
-        8b1b735a65d99f21e70dbc020bfdface9f724a0d1fb5895db971cc81aa7608baa0920abb0a565c9c
-        436e2fd13323428296c86385f2384e408a31e104670df0791d93e743a3a5194ee6b076fb6323ca59
-        3011b7348c16cf58f66b9633906ba54a2ee803187344b394f75dd2e663a57b956cb830dd7a908d4f
-        39a2336a61ef9fda549180d4ccde21514d117b6c6fd07a9102b5efe710a32af4eeacae2cb3b1dec0
-        35b9593b48b9d3ca4c13d245d5f04169b0b1
-        "
-        );
-
-        eip8_test_server().read_auth(&mut auth2.to_vec()).unwrap();
-        eip8_test_server().read_auth(&mut auth3.to_vec()).unwrap();
-
+    /// EIP-8 auth/ack round-trip with protocol version 5 (AES-256-CTR handshake).
+    ///
+    /// Standard EIP-8 test vectors from <https://eips.ethereum.org/EIPS/eip-8> use AES-128-CTR
+    /// and are not applicable after the 0G AES-256 handshake extension.
+    fn eip8_handshake_round_trip() {
         let mut test_client = eip8_test_client();
         let mut test_server = eip8_test_server();
 
         test_server.read_auth(&mut test_client.create_auth()).unwrap();
-
         test_client.read_ack(&mut test_server.create_ack()).unwrap();
-
-        test_client.read_ack(&mut ack2.to_vec()).unwrap();
-        test_client.read_ack(&mut ack3.to_vec()).unwrap();
     }
 
     #[test]

--- a/docs/post-quantum-audit-response-en.md
+++ b/docs/post-quantum-audit-response-en.md
@@ -1,0 +1,227 @@
+# 0G Post-Quantum Audit Response Report (Draft)
+
+> **Audit source**: Tectonic Labs — [0G] 1-Day Post-Quantum Audit Report (January 2026)  
+> **Report date**: June 11, 2026  
+> **Scope**: This document focuses on **chain-related** and **execution layer (EL)** findings only. It does not include a full inventory of Storage / DA / Compute network issues.
+
+---
+
+## 1. Executive Summary
+
+The Tectonic quantum readiness audit identified **21** findings in total. Mapped to the 0G architecture, **7** findings are directly related to the chain and execution layer:
+
+| Status | Count | Description |
+|--------|-------|-------------|
+| **Fixed** | 2 | TEC-09 (chain RPC TLS key exchange), TEC-16 (RLPx ECIES AES-256 handshake) |
+| **Not yet fixed** | 5 | TEC-11, TEC-17–TEC-20 (EL layer) |
+
+The remaining open EL items are not being ignored. They are constrained by **EVM ecosystem standards, protocol-level dependencies, and the maturity of post-quantum replacements**, and must be addressed in coordination with Ethereum and the broader industry migration path.
+
+---
+
+## 2. Layer Classification
+
+### 2.1 Chain vs. Execution Layer
+
+| Layer | Definition | Components |
+|-------|------------|------------|
+| **Chain** | Public entry points and on-chain interaction infrastructure for users and services | EVM RPC endpoints (`evmrpc.*.0g.ai`), on-chain transaction signing, etc. |
+| **EL (Execution Layer)** | 0G Reth execution client and its cryptographic implementations | `0g-reth`: P2P, transaction pool, RPC signing, EIP-4844, etc. |
+
+> **Note**: The audit report classifies TEC-09 under "0G Storage Network - Client." However, the affected endpoints `evmrpc-testnet.0g.ai` and `evmrpc.0g.ai` are **chain EVM RPC entry points**, and the DA service also uses this RPC (as noted in TEC-10). TEC-09 should therefore be treated as a **chain infrastructure issue**, not Storage-specific logic.
+
+---
+
+## 3. Fixed Issues
+
+### 3.1 TEC-09 — Chain RPC TLS Key Exchange
+
+#### Issue Overview
+
+| Field | Details |
+|-------|---------|
+| **ID** | TEC-09 |
+| **Title** | RPC endpoints with quantum-vulnerable TLS key exchange |
+| **Severity / Urgency** | High / **Critical** |
+| **Risk type** | Harvest-Now-Decrypt-Later (HNDL) |
+
+At the time of the audit, all endpoints except RPC Testnet supported only TLS 1.2 and lacked post-quantum or hybrid key exchange:
+
+| Endpoint | TLS version (at audit) | PQ key exchange (at audit) |
+|----------|------------------------|----------------------------|
+| `evmrpc-testnet.0g.ai:443` | TLS 1.3 | X25519MLKEM768 ✓ |
+| `evmrpc.0g.ai:443` | TLS 1.2 | No |
+| `indexer-storage-testnet-turbo.0g.ai:443` | TLS 1.2 | No |
+| `indexer-storage-turbo.0g.ai:4443` | TLS 1.2 | No |
+
+#### Remediation
+
+**Status: Fixed**
+
+TLS upgrades have been completed for chain-related RPC endpoints:
+
+1. **Upgraded to TLS 1.3** with post-quantum or hybrid key exchange support (e.g., X25519MLKEM768).
+2. **Covered high-risk endpoints** flagged in the audit, including mainnet RPC (`evmrpc.0g.ai`).
+3. **Aligned CDN / load balancer and certificate configuration** with documentation.
+
+---
+
+### 3.2 TEC-16 — RLPx ECIES Handshake AES-128-CTR
+
+#### Issue Overview
+
+| Field | Details |
+|-------|---------|
+| **ID** | TEC-16 |
+| **Title** | ECIES message encryption based on AES-128-CTR |
+| **Location** | `crates/net/ecies/src/algorithm.rs` |
+| **Severity / Urgency** | Informational / Informational |
+| **Risk** | Grover's algorithm reduces AES-128 effective strength to ~128 bits; CNSA 2.0 recommends Category 5 (AES-256) |
+
+The audit flagged AES-128-CTR usage during the **RLPx ECIES handshake** (auth/ack messages). Note that post-handshake RLPx frame encryption already used AES-256-CTR in 0G Reth.
+
+#### Remediation
+
+**Status: Fixed**
+
+Because the 0G chain runs **only 0G Reth** as its execution client (no Geth or other third-party EL nodes), we upgraded the ECIES handshake to AES-256 without requiring Ethereum ecosystem coordination:
+
+1. **Extended key derivation** from `KDF(S, 32)` to `KDF(S, 48)` — 32-byte encryption key + 16-byte MAC material.
+2. **Switched handshake encryption** from `AES-128-CTR` to `AES-256-CTR` in `encrypt_message()` and `decrypt()`.
+3. **Bumped RLPx handshake protocol version** from `4` to `5` to signal the 0G extension.
+
+**Deployment note**: All EL nodes must run a build that includes this change. Nodes on protocol version 4 (AES-128 handshake) cannot complete RLPx handshakes with version 5 nodes.
+
+---
+
+## 4. Not Yet Fixed: EL Layer Issues
+
+Five EL findings remain open (TEC-11, TEC-17–TEC-20). Each item below describes the issue, impact, and rationale for deferral.
+
+---
+
+### 4.1 TEC-11 — Blockchain Transaction Signing with ECDSA (Critical)
+
+| Field | Details |
+|-------|---------|
+| **Location** | 0G Storage Client (`common/blockchain/`, `transfer/uploader.go`, etc.) |
+| **Issue** | secp256k1 ECDSA is used to sign on-chain transactions |
+| **Risk** | Quantum computers could break ECDSA and forge transaction signatures |
+| **Severity / Urgency** | Critical / Medium |
+
+**Why not fixed yet:**
+
+- The 0G chain is **EVM-compatible**; account model and signature verification depend on Ethereum-standard ECDSA (EIP-155, etc.).
+- No standardized EVM post-quantum account type or hard-fork path exists yet (see [Tasklist for post-quantum ETH](https://ethresear.ch/t/tasklist-for-post-quantum-eth/21296)).
+- Client-side changes alone would break on-chain validation; migration must be synchronized across the ecosystem.
+
+---
+
+### 4.2 TEC-17 — EIP-4844 Blob Transaction Validation with KZG (High)
+
+| Field | Details |
+|-------|---------|
+| **Location** | `crates/transaction-pool/src/validate/eth.rs`, `crates/rpc/rpc/src/validation.rs`, etc. |
+| **Issue** | Blob integrity verification relies on KZG polynomial commitments (BN254, vulnerable to Shor's algorithm) |
+| **Risk** | Attackers could forge blob commitments, affecting DA data integrity |
+| **Severity / Urgency** | High / Medium |
+
+**Why not fixed yet:**
+
+- KZG is part of the **EIP-4844** standard; 0G Reth must implement it.
+- No drop-in post-quantum polynomial commitment standard or Ethereum EIP exists yet.
+- Shared with DA-layer TEC-15; requires ecosystem-wide migration.
+
+---
+
+### 4.3 TEC-18 — Keccak-256 Hash Usage (Informational)
+
+| Field | Details |
+|-------|---------|
+| **Location** | Trie, ECIES MAC, DiscV4, transaction hashing, etc. |
+| **Issue** | Keccak-256 used extensively; not aligned with CNSA 2.0 SHA3-384/512 recommendations |
+| **Severity / Urgency** | Informational / Informational |
+
+**Why not fixed yet:**
+
+- Keccak-256 is foundational to Ethereum state trie, addresses, and transaction hashes.
+- Auditors recommend **no migration** ("No migration seems required"); 128-bit post-quantum strength remains adequate.
+
+---
+
+### 4.4 TEC-19 — RLPx ECDH Key Exchange (Medium)
+
+| Field | Details |
+|-------|---------|
+| **Location** | `crates/net/ecies/src/algorithm.rs` |
+| **Issue** | RLPx P2P handshake uses secp256k1 ECDH |
+| **Risk** | HNDL against encrypted P2P traffic |
+| **Severity / Urgency** | Medium / Medium |
+
+**Why not fixed yet:**
+
+- ECDH is inherent to the RLPx protocol design.
+- Post-quantum P2P (e.g., ML-KEM hybrid handshakes) is still under research ([PSE: quantum-safe P2P](https://pse.dev/blog/towards_a_quantum-safe_p2p_for_ethereum)).
+- RLPx payload is ultimately public on-chain, limiting practical HNDL value.
+
+---
+
+### 4.5 TEC-20 — Reth Blockchain Transaction Signing with ECDSA (Critical)
+
+| Field | Details |
+|-------|---------|
+| **Location** | `crates/rpc/rpc/src/eth/helpers/signer.rs`, `crates/ethereum/primitives/src/transaction.rs`, etc. |
+| **Issue** | Reth uses secp256k1 ECDSA for on-chain and RPC signing |
+| **Risk** | Signature forgery enabling unauthorized transactions and fund theft |
+| **Severity / Urgency** | Critical / Medium |
+
+**Why not fixed yet:**
+
+- Same structural dependency as TEC-11; requires new account/transaction type EIPs and hard-fork activation.
+- 0G will follow the Ethereum post-quantum migration path.
+
+---
+
+## 5. EL Layer Summary
+
+| ID | Title | Severity | Urgency | Status | Notes |
+|----|-------|----------|---------|--------|-------|
+| TEC-11 | On-chain transaction ECDSA signing (Storage Client) | Critical | Medium | Open | Awaiting EVM PQ signing standard |
+| TEC-16 | ECIES AES-128-CTR handshake | Info | Info | **Fixed** | Upgraded to AES-256-CTR, protocol v5 |
+| TEC-17 | EIP-4844 KZG validation | High | Medium | Open | No PQ polynomial commitment standard |
+| TEC-18 | Keccak-256 usage | Info | Info | Open | Auditors recommend no migration |
+| TEC-19 | RLPx ECDH key exchange | Medium | Medium | Open | Ethereum PQ P2P still in research |
+| TEC-20 | Reth transaction ECDSA signing | Critical | Medium | Open | Requires Ethereum hard-fork-level migration |
+
+---
+
+## 6. Conclusions and Next Steps
+
+### 6.1 Completed Actions
+
+- **TEC-09 (chain RPC TLS)**: Fixed — TLS 1.3 with post-quantum/hybrid key exchange deployed on chain RPC endpoints.
+- **TEC-16 (ECIES AES-128 handshake)**: Fixed — RLPx ECIES handshake upgraded to AES-256-CTR (protocol version 5) in `0g-reth`.
+
+### 6.2 Rationale for Open EL Items
+
+1. **Structural dependencies (TEC-11, TEC-17, TEC-19, TEC-20)** — rooted in Ethereum / EVM standards; require ecosystem-level migration.
+2. **Compliance annotation (TEC-18)** — auditors recommend no migration; lower priority than authentication findings.
+
+### 6.3 Ongoing Tracking
+
+| Priority | Action |
+|----------|--------|
+| P0 (ongoing) | Track [Ethereum Post-Quantum Tasklist](https://ethresear.ch/t/tasklist-for-post-quantum-eth/21296) and PSE progress |
+| P1 (mid-term) | Monitor PQ polynomial commitments and signature aggregation (TEC-17, DA-layer TEC-15) |
+| P2 (long-term) | Implement PQ account types / PQ RLPx once defined by Ethereum; coordinate hard fork |
+| Operations | Maintain post-quantum TLS on chain RPC endpoints; ensure all EL nodes run AES-256 handshake builds |
+
+---
+
+## Appendix: Original Severity Distribution (All 21 Findings)
+
+| Critical | High | Medium | Low | Informational |
+|----------|------|--------|-----|---------------|
+| 2 | 8 | 3 | 0 | 8 |
+
+*Note: The audit assigned 0G QTRL-0 (Exposed), primarily due to HNDL vulnerabilities. TEC-09 and TEC-16 remediation reduces exposure on chain entry points and EL P2P handshake compliance. Remaining EL risk follows industry migration timelines.*


### PR DESCRIPTION
Bump handshake protocol version to 5 and derive a 32-byte encryption key via KDF(S, 48) to address post-quantum audit finding TEC-16. Add tokio dev-dependencies for stream tests and update the EN audit response doc.