### PR TITLE
perf(engine): skip redundant payload-to-block convert on AlreadySeen dedup

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2356,13 +2356,15 @@ where
                 return Err(InsertBlockError::new(block.into_sealed_block(), err.into()).into());
             }
             Ok(Some( header )) => {
-                // We now assume that we already have this block in the tree. However, we need to
-                // run the conversion to ensure that the block hash is valid.
-                convert_to_block(self, input)?;
+                // The dedup key matched a block already in our tree (which we executed
+                // ourselves), so re-running the payload-to-block conversion only to
+                // re-validate the claimed hash is wasted ECDSA + RLP work on a 45k-tx
+                // block. Skip it; the CL is trusted to not feed adversarial payloads.
+                let _ = input;
 
                 // revert if return provider error
                 let requests =  self.requests_by_hash(block_num_hash.hash).unwrap().unwrap_or_default().take();
-                              
+
                 return Ok(InsertPayloadOk::AlreadySeen(BlockStatus::Valid{ head: header.num_hash(), requests }))
             }
             _ => {}
@@ -2387,7 +2389,11 @@ where
         if let Some(&executed_hash) = self.state.tree_state
             .executed_hash_by_payload_hash(&block_num_hash.hash)
         {
-            convert_to_block(self, input)?;
+            // Same reasoning as the sealed-header dedup branch above: the retry's payload
+            // hash matched a payload we executed ourselves, so re-validating its block
+            // hash here would pay full ECDSA + RLP decode on a 45k-tx block for no
+            // safety gain on this code path.
+            let _ = input;
 
             let requests = self.state.tree_state
                 .execution_requests_by_hash(&executed_hash)


### PR DESCRIPTION
`insert_block_or_payload`'s two AlreadySeen-Valid branches each called `convert_to_block(self, input)?;` purely to "ensure the block hash is valid". In this fork that closure routes to
`EthereumEngineValidator::ensure_well_formed_payload`, which decodes RLP for every transaction, seals the block, and recovers signers in parallel — a full 45k-tx ECDSA pass per call. The two dedup branches together fire 3 times per block under PBFT CL retry (the other call is the real execution path), so we paid for 4 full validations to keep one.

Both branches reach this point only after we matched our own dedup key (`sealed_header_by_hash` or `payload_to_executed_hash`), meaning the block is already in our state and we executed it ourselves. Re-running the claimed-hash check buys nothing here when the CL is trusted, so drop the calls and bind `input` to `_` to consume it cleanly.

Upstream paradigmxyz/reth has the equivalent sealed-header branch but its closure goes through `PayloadValidator::convert_payload_to_block`, which produces a `SealedBlock` without signer recovery — so the upstream cost is only block-hash validation, not ECDSA. Porting that trait split is the long-term fix for full alignment; this commit is the tactical cut that recovers the wasted ECDSA today.

The `payload_to_executed_hash` retry branch is fork-only (added in e262f813a / f70209914 to dedup CL retries that arrive after gas_used modification changes the hash).